### PR TITLE
from static_frame import Index for lines 749, 750

### DIFF
--- a/static_frame/core/util.py
+++ b/static_frame/core/util.py
@@ -12,8 +12,7 @@ from functools import wraps
 
 import numpy as np
 
-from static_frame import Index
-
+from static_frame.core.index import Index
 
 # min/max fail on object arrays
 # handle nan in object blocks with skipna processing on ufuncs

--- a/static_frame/core/util.py
+++ b/static_frame/core/util.py
@@ -12,6 +12,7 @@ from functools import wraps
 
 import numpy as np
 
+from static_frame import Index
 
 
 # min/max fail on object arrays


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/InvestmentSystems/static-frame on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./static_frame/test/unit/test_frame.py:2443:9: F821 undefined name 'frame'
        frame.loc[sf.ILoc[-1], ['id', 'title', 'url']]
        ^
./static_frame/core/util.py:722:35: F821 undefined name 'FrameAsType'
    def __getitem__(self, key) -> 'FrameAsType':
                                  ^
./static_frame/core/util.py:748:24: F821 undefined name 'Index'
            src_index: 'Index',
                       ^
./static_frame/core/util.py:749:24: F821 undefined name 'Index'
            dst_index: 'Index') -> 'IndexCorrespondence':
                       ^
./static_frame/core/index_base.py:89:38: F821 undefined name 'Index'
    def intersection(self, other) -> 'Index':
                                     ^
./static_frame/core/index_base.py:101:31: F821 undefined name 'Index'
    def union(self, other) -> 'Index':
                              ^
./static_frame/core/index_hierarchy.py:916:16: F821 undefined name '_ufunc_skipna_1d'
        return _ufunc_skipna_1d(
               ^
./static_frame/core/index.py:630:28: F821 undefined name 'Series'
    def to_series(self) -> 'Series':
                           ^
./static_frame/core/index.py:637:48: F821 undefined name 'IndexHierarchy'
    def add_level(self, level: tp.Hashable) -> 'IndexHierarchy':
                                               ^
9     F821 undefined name 'Series'
9
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree