### PR TITLE
Specify channel in conda installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Install StaticFrame via PIP::
 
 Or, install StaticFrame via conda::
 
-    conda install static-frame
+    conda install -c conda-forge static-frame
 
 
 Dependencies


### PR DESCRIPTION
Making explicit that when installing from conda, static-frame needs to use conda-forge channel. I guess it's assumed to be in the user settings, but that's probably not the case for most users.