### PR TITLE
python -m static_frame

### DIFF
--- a/static_frame/__main__.py
+++ b/static_frame/__main__.py
@@ -1,0 +1,69 @@
+'''Drop into an interactive interpreter pre-loaded with sf, np, and (if installed) pd.
+
+$ python -m static_frame
+$ ipython -m static_frame
+'''
+
+
+from code import interact
+from sys import platform
+from sys import version
+
+import numpy as np
+
+import static_frame as sf
+
+
+imports = {'np': np, 'sf': sf}
+
+
+try:  # Import pandas, if it's installed:
+    import pandas as pd
+except ImportError:
+    pass
+else:
+    imports['pd'] = pd
+
+
+commands = sorted(
+        f'import {package.__name__} as {name}  # {package.__version__}'
+        for name, package in imports.items()
+)
+
+
+try:  # This lets us play nicely with IPython:
+
+    from builtins import __IPYTHON__  # type: ignore
+
+    from IPython import embed
+    from IPython import get_ipython
+
+except ImportError:
+    is_ipython = False
+
+else:
+    is_ipython = __IPYTHON__
+
+
+if __name__ == '__main__':
+
+    if is_ipython:
+
+        ipython = get_ipython()
+
+        print()  # Spacer.
+        
+        for command in commands:
+            ipython.auto_rewrite_input(command)
+            
+        print()  # Spacer.
+
+        embed(user_ns=imports, colors='neutral')
+
+    else:
+
+        banner = f'Python {version} on {platform}\n' + '\n'.join(
+                f'>>> {command}' for command in commands
+        )
+
+        interact(banner=banner, local=imports)


### PR DESCRIPTION
Now, running `python -m static_frame` or `ipython -m static_frame` drops you into an interactive interpreter with `sf`, `np`, and (if installed) `pd` pre-loaded. Here is what that looks like (in each case, the user hasn't interacted yet):

```
$ python -m static_frame
Python 3.7.3 (default, Jun  7 2019, 15:55:34) 
[GCC 5.4.0 20160609] on linux
>>> import numpy as np  # 1.15.1
>>> import pandas as pd  # 0.23.4
>>> import static_frame as sf  # 0.3.5-dev
>>> 
```

`IPython` gets to keep its colored output (can't see it here, obviously):

```
$ ipython -m static_frame

------> import numpy as np  # 1.15.1
------> import pandas as pd  # 0.23.4
------> import static_frame as sf  # 0.3.5-dev

Python 3.7.3 (default, Jun  7 2019, 15:55:34) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: 
```