### PR TITLE
Index.__reversed__

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,5 @@ Pygments==2.2.0
 sphinx-jinja==0.3.0
 sphinxcontrib-napoleon==0.6.1
 sphinx_rtd_theme>=0.3.1
-sphinx-jinja==0.3.0
 hypothesis==3.71.3
 pandas==0.23.4

--- a/static_frame/core/index.py
+++ b/static_frame/core/index.py
@@ -286,18 +286,6 @@ class Index(IndexBase,
             # resolving the detype is expensive
             labels = collection_to_array(labels, dtype=dtype, discover_dtype=True)
 
-            # if not len(labels):
-            #     return EMPTY_ARRAY # already immutable
-
-            # if isinstance(labels[0], tuple):
-            #     # special handling for iterables of
-            #     assert dtype is None or dtype == object
-            #     array = np.empty(len(labels), object)
-            #     array[:] = labels
-            #     labels = array # rename
-            # else:
-            #     labels = np.array(labels, dtype)
-
         else: # labels may be an expired generator, must use the mapping
 
             # TODO: explore why this does not work
@@ -750,12 +738,6 @@ class Index(IndexBase,
         '''
         return self._map.keys()
 
-    def __iter__(self):
-        '''Iterate over labels.
-        '''
-        if self._recache:
-            self._update_array_cache()
-        return self._labels.__iter__()
 
     def __contains__(self, value) -> bool:
         '''Return True if value in the labels.

--- a/static_frame/core/index.py
+++ b/static_frame/core/index.py
@@ -430,6 +430,12 @@ class Index(IndexBase,
         # NOTE: automatic discovery is possible, but not yet implemented
         self._loc_is_iloc = loc_is_iloc
 
+    def __reversed__(self) -> tp.Iterator[tp.Hashable]:
+        '''
+        Returns a reverse iterator on the index labels.
+        '''
+        return reversed(self.values)
+
     #---------------------------------------------------------------------------
     def __setstate__(self, state):
         '''

--- a/static_frame/core/index_base.py
+++ b/static_frame/core/index_base.py
@@ -164,6 +164,15 @@ class IndexBase:
         cls = self.__class__
         return cls.from_labels(cls._UFUNC_UNION(self._labels, opperand))
 
+    #---------------------------------------------------------------------------
+    # dictionary-like interface
+
+    def __iter__(self):
+        '''Iterate over labels.
+        '''
+        if self._recache:
+            self._update_array_cache()
+        return self._labels.__iter__()
 
     #---------------------------------------------------------------------------
     # common display

--- a/static_frame/core/index_base.py
+++ b/static_frame/core/index_base.py
@@ -174,6 +174,14 @@ class IndexBase:
             self._update_array_cache()
         return self._labels.__iter__()
 
+    def __reversed__(self) -> tp.Iterable[tp.Hashable]:
+        '''
+        Returns a reverse iterator on the index labels.
+        '''
+        if self._recache:
+            self._update_array_cache()
+        return reversed(self._labels)
+
     #---------------------------------------------------------------------------
     # common display
 

--- a/static_frame/core/index_hierarchy.py
+++ b/static_frame/core/index_hierarchy.py
@@ -648,14 +648,6 @@ class IndexHierarchy(IndexBase,
             self._update_array_cache()
         return self._keys
 
-    def __iter__(self):
-        '''Iterate over labels.
-        '''
-        if self._recache:
-            self._update_array_cache()
-        # TODO: replace with iter of self._keys on 3.6
-        return self._labels.__iter__()
-
     def __contains__(self, value) -> bool:
         '''Determine if a leaf loc is contained in this Index.
         '''

--- a/static_frame/core/type_blocks.py
+++ b/static_frame/core/type_blocks.py
@@ -205,6 +205,17 @@ class TypeBlocks(metaclass=MetaOperatorDelegate):
         return a
 
     @property
+    def shapes(self) -> np.ndarray:
+        '''
+        Return an immutable array that, for each block, reports the shape as a tuple.
+        '''
+        a = np.empty(len(self._blocks), dtype=object)
+        a[:] = [b.shape for b in self._blocks]
+        a.flags.writeable = False
+        return a
+
+
+    @property
     def mloc(self) -> np.ndarray:
         '''Return an immutable ndarray of NP array memory location integers.
         '''

--- a/static_frame/test/property/strategies.py
+++ b/static_frame/test/property/strategies.py
@@ -9,30 +9,30 @@ from hypothesis.extra import numpy as hypo_np
 import numpy as np
 
 MAX_ROWS = 10
-MAX_COLUMNS = 10
+MAX_COLUMNS = 20
 
 def get_dtype():
     return hypo_np.scalar_dtypes()
 
 def get_dtypes(min_size: int = 0) -> tp.Iterable[np.dtype]:
-    return st.lists(hypo_np.scalar_dtypes(), min_size=min_size)
+    return st.lists(get_dtype(), min_size=min_size)
 
 def get_dtype_pairs() -> tp.Tuple[np.dtype]:
-    return st.tuples(hypo_np.scalar_dtypes(), hypo_np.scalar_dtypes())
+    return st.tuples(get_dtype(), get_dtype())
+
+#-------------------------------------------------------------------------------
+# array generation
 
 def get_array_1d(
         min_size: int = 0,
-        max_size: int = 10,
+        max_size: int = MAX_ROWS,
         unique: bool = False):
     shape = st.integers(min_value=min_size, max_value=max_size)
 
     return hypo_np.arrays(
-            hypo_np.scalar_dtypes(),
+            get_dtype(),
             shape,
-            elements=None,
-            fill=None,
             unique=False)
-
 
 def get_shape_2d(
         min_rows=1,
@@ -44,7 +44,6 @@ def get_shape_2d(
             st.integers(min_value=min_rows, max_value=max_rows),
             st.integers(min_value=min_columns, max_value=max_columns)
             )
-
 
 def get_shape_1d2d() -> tp.Union[tp.Tuple[int], tp.Tuple[int, int]]:
     return st.one_of(get_shape_2d(), st.tuples(st.integers(min_value=1, max_value=MAX_ROWS)))
@@ -63,35 +62,88 @@ def get_array_2d(
             max_columns=max_columns)
 
     return hypo_np.arrays(
-            hypo_np.scalar_dtypes(),
+            get_dtype(),
             shape=shape,
-            elements=None,
-            fill=None,
             unique=False)
 
-def get_array_1d2d():
-    return st.one_of(get_array_1d(), get_array_2d())
+def get_array_1d2d(
+        min_rows=1,
+        max_rows=MAX_ROWS,
+        min_columns=1,
+        max_columns=MAX_COLUMNS,
+        ):
+    '''
+    For convenience in building blocks, treat row constraints as 1d size constraints.
+    '''
+    return st.one_of(
+            get_array_2d(min_rows=min_rows,
+                    max_rows=max_rows,
+                    min_columns=min_columns,
+                    max_columns=max_columns),
+            get_array_1d(min_size=min_rows, max_size=max_rows)
+    )
+
+#-------------------------------------------------------------------------------
+# aligend arrays for concatenation and type blocks
 
 def get_arrays_2d_aligned_columns(min_size: int = 1, max_size: int = 10):
 
-    columns = st.integers(min_value=1, max_value=MAX_COLUMNS).example()
-
-    return st.lists(
+    return st.integers(min_value=1, max_value=MAX_COLUMNS).flatmap(
+        lambda columns: st.lists(
             get_array_2d(min_columns=columns, max_columns=columns),
             min_size=min_size,
             max_size=max_size
             )
+    )
+
 
 def get_arrays_2d_aligned_rows(min_size: int = 1, max_size: int = 10):
 
-    rows = st.integers(min_value=1, max_value=MAX_ROWS).example()
-
-    return st.lists(
+    return st.integers(min_value=1, max_value=MAX_ROWS).flatmap(
+        lambda rows: st.lists(
             get_array_2d(min_rows=rows, max_rows=rows),
             min_size=min_size,
             max_size=max_size
             )
+    )
 
+def get_blocks(
+        min_rows=1,
+        max_rows=MAX_ROWS,
+        min_columns=1,
+        max_columns=MAX_COLUMNS,
+        ):
+    '''
+    Args:
+        min_columns: number of resultant columns in combination of all arrays.
+    '''
+
+    def get_arrays(pair):
+        rows, columns = pair
+
+        def is_valid(blocks):
+            '''Filter to block combinations that sum to targetted columns
+            '''
+            return sum(1 if b.ndim == 1 else b.shape[1] for b in blocks) == columns
+
+        return st.lists(get_array_1d2d(
+                    min_rows=rows,
+                    max_rows=rows,
+                    min_columns=1,
+                    max_columns=columns
+                    ),
+                min_size=1,
+                max_size=columns
+                ).filter(is_valid)
+
+    return st.tuples(
+            st.integers(min_value=min_rows, max_value=max_rows),
+            st.integers(min_value=min_columns, max_value=max_columns)
+            ).flatmap(
+        get_arrays
+    )
+
+#-------------------------------------------------------------------------------
 # 55203 is just before "high surrogates", and avoids this exception
 # UnicodeDecodeError: 'utf-32-le' codec can't decode bytes in position 0-3: code point in surrogate code point range(0xd800, 0xe000)
 ST_CODEPOINT_LIMIT = dict(min_codepoint=1, max_codepoint=55203)
@@ -101,24 +153,40 @@ ST_LABEL = (st.dates,
         st.integers,
         st.floats,
         st.complex_numbers,
+        # st.decimals,
+        st.fractions,
         partial(st.characters, **ST_CODEPOINT_LIMIT),
         partial(st.text, st.characters(**ST_CODEPOINT_LIMIT))
     )
 
+ST_VALUE = ST_LABEL + (st.booleans, st.none)
+
+
+def get_value():
+    '''
+    Any plausible value.
+    '''
+    return st.one_of(strat() for strat in ST_VALUE)
+
+
 def get_label():
+    '''
+    A hashable suitable for use in an Index.
+    '''
     return st.one_of(strat() for strat in ST_LABEL)
 
 def get_labels(min_size: int = 0):
     '''
     Labels are suitable for creating non-date Indices (though they might be dates)
     '''
-    list_mixed = st.lists(st.one_of(strat() for strat in ST_LABEL),
+    # drawing from value so as to include None and booleans
+    list_mixed = st.lists(st.one_of(strat() for strat in ST_VALUE),
             min_size=min_size,
             unique=True)
 
     lists = chain(
+            (list_mixed,),
             (st.lists(strat(), min_size=min_size, unique=True) for strat in ST_LABEL),
-            (list_mixed,)
             )
     return st.one_of(lists)
 
@@ -129,12 +197,45 @@ def get_labels(min_size: int = 0):
 
 if __name__ == '__main__':
     from static_frame.core.display_color import HexColor
+    import fnmatch
+    import sys
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser()
+    parser.add_argument('-n', '--name', default=None)
+    parser.add_argument('-c', '--count', default=3, type=int)
+    options = parser.parse_args()
 
     local_items = tuple(locals().items())
     for v in (v for k, v in local_items if callable(v) and k.startswith('get')):
 
-        print(HexColor.format_terminal('hotpink', str(v)))
+        if options.name:
+            if not fnmatch.fnmatch(v.__name__, options.name):
+                continue
 
+        print(HexColor.format_terminal('grey', '.' * 50))
+        print(HexColor.format_terminal('hotpink', str(v.__name__)))
 
-        for x in range(4    ):
+        for x in range(options.count):
+            print(HexColor.format_terminal('grey', '.' * 50))
             print(v().example())
+
+
+
+
+
+
+
+
+
+
+# columns = st.integers(min_value=1, max_value=MAX_COLUMNS).example()
+
+# return st.lists(
+#         get_array_2d(min_columns=columns, max_columns=columns),
+#         min_size=min_size,
+#         max_size=max_size
+#         )
+
+
+

--- a/static_frame/test/property/strategies.py
+++ b/static_frame/test/property/strategies.py
@@ -1,4 +1,5 @@
 import typing as tp
+from enum import Enum
 
 from functools import partial
 from itertools import chain
@@ -8,140 +9,26 @@ from hypothesis.extra import numpy as hypo_np
 
 import numpy as np
 
+from static_frame.core.util import DTYPE_OBJECT
+
+from static_frame import TypeBlocks
+from static_frame import Index
+
+from static_frame import IndexDate
+from static_frame import IndexYear
+from static_frame import IndexYearMonth
+from static_frame import IndexSecond
+from static_frame import IndexMillisecond
+
+from static_frame import IndexGO
+from static_frame import Series
+from static_frame import Frame
+from static_frame import FrameGO
+
 MAX_ROWS = 10
 MAX_COLUMNS = 20
 
-def get_dtype():
-    return hypo_np.scalar_dtypes()
 
-def get_dtypes(min_size: int = 0) -> tp.Iterable[np.dtype]:
-    return st.lists(get_dtype(), min_size=min_size)
-
-def get_dtype_pairs() -> tp.Tuple[np.dtype]:
-    return st.tuples(get_dtype(), get_dtype())
-
-#-------------------------------------------------------------------------------
-# array generation
-
-def get_array_1d(
-        min_size: int = 0,
-        max_size: int = MAX_ROWS,
-        unique: bool = False):
-    shape = st.integers(min_value=min_size, max_value=max_size)
-
-    return hypo_np.arrays(
-            get_dtype(),
-            shape,
-            unique=False)
-
-def get_shape_2d(
-        min_rows=1,
-        max_rows=MAX_ROWS,
-        min_columns=1,
-        max_columns=MAX_COLUMNS,
-        ):
-    return st.tuples(
-            st.integers(min_value=min_rows, max_value=max_rows),
-            st.integers(min_value=min_columns, max_value=max_columns)
-            )
-
-def get_shape_1d2d() -> tp.Union[tp.Tuple[int], tp.Tuple[int, int]]:
-    return st.one_of(get_shape_2d(), st.tuples(st.integers(min_value=1, max_value=MAX_ROWS)))
-
-def get_array_2d(
-        min_rows=1,
-        max_rows=MAX_ROWS,
-        min_columns=1,
-        max_columns=MAX_COLUMNS,
-        ):
-
-    shape = get_shape_2d(
-            min_rows=min_rows,
-            max_rows=max_rows,
-            min_columns=min_columns,
-            max_columns=max_columns)
-
-    return hypo_np.arrays(
-            get_dtype(),
-            shape=shape,
-            unique=False)
-
-def get_array_1d2d(
-        min_rows=1,
-        max_rows=MAX_ROWS,
-        min_columns=1,
-        max_columns=MAX_COLUMNS,
-        ):
-    '''
-    For convenience in building blocks, treat row constraints as 1d size constraints.
-    '''
-    return st.one_of(
-            get_array_2d(min_rows=min_rows,
-                    max_rows=max_rows,
-                    min_columns=min_columns,
-                    max_columns=max_columns),
-            get_array_1d(min_size=min_rows, max_size=max_rows)
-    )
-
-#-------------------------------------------------------------------------------
-# aligend arrays for concatenation and type blocks
-
-def get_arrays_2d_aligned_columns(min_size: int = 1, max_size: int = 10):
-
-    return st.integers(min_value=1, max_value=MAX_COLUMNS).flatmap(
-        lambda columns: st.lists(
-            get_array_2d(min_columns=columns, max_columns=columns),
-            min_size=min_size,
-            max_size=max_size
-            )
-    )
-
-
-def get_arrays_2d_aligned_rows(min_size: int = 1, max_size: int = 10):
-
-    return st.integers(min_value=1, max_value=MAX_ROWS).flatmap(
-        lambda rows: st.lists(
-            get_array_2d(min_rows=rows, max_rows=rows),
-            min_size=min_size,
-            max_size=max_size
-            )
-    )
-
-def get_blocks(
-        min_rows=1,
-        max_rows=MAX_ROWS,
-        min_columns=1,
-        max_columns=MAX_COLUMNS,
-        ):
-    '''
-    Args:
-        min_columns: number of resultant columns in combination of all arrays.
-    '''
-
-    def get_arrays(pair):
-        rows, columns = pair
-
-        def is_valid(blocks):
-            '''Filter to block combinations that sum to targetted columns
-            '''
-            return sum(1 if b.ndim == 1 else b.shape[1] for b in blocks) == columns
-
-        return st.lists(get_array_1d2d(
-                    min_rows=rows,
-                    max_rows=rows,
-                    min_columns=1,
-                    max_columns=columns
-                    ),
-                min_size=1,
-                max_size=columns
-                ).filter(is_valid)
-
-    return st.tuples(
-            st.integers(min_value=min_rows, max_value=max_rows),
-            st.integers(min_value=min_columns, max_value=max_columns)
-            ).flatmap(
-        get_arrays
-    )
 
 #-------------------------------------------------------------------------------
 # 55203 is just before "high surrogates", and avoids this exception
@@ -168,42 +55,414 @@ def get_value():
     '''
     return st.one_of(strat() for strat in ST_VALUE)
 
-
 def get_label():
     '''
     A hashable suitable for use in an Index.
     '''
     return st.one_of(strat() for strat in ST_LABEL)
 
-def get_labels(min_size: int = 0):
+def get_labels(
+        min_size: int = 0,
+        max_size: int = MAX_ROWS):
     '''
-    Labels are suitable for creating non-date Indices (though they might be dates)
+    Labels are suitable for creating non-date Indices (though they might include dates)
     '''
     # drawing from value so as to include None and booleans
-    list_mixed = st.lists(st.one_of(strat() for strat in ST_VALUE),
+    list_mixed = st.lists(get_value(),
             min_size=min_size,
+            max_size=max_size,
             unique=True)
 
     lists = chain(
             (list_mixed,),
-            (st.lists(strat(), min_size=min_size, unique=True) for strat in ST_LABEL),
+            (st.lists(
+                    strat(),
+                    min_size=min_size,
+                    max_size=max_size,
+                    unique=True) for strat in ST_LABEL),
             )
     return st.one_of(lists)
 
+
+#-------------------------------------------------------------------------------
+# dtypes
+
+class DTGroup(Enum):
+    ALL = (hypo_np.scalar_dtypes,)
+    OBJECT = (partial(st.just, DTYPE_OBJECT), ) # strategy constantly generating object dtype
+
+    NUMERIC = (hypo_np.floating_dtypes,
+            hypo_np.integer_dtypes,
+            hypo_np.complex_number_dtypes)
+    STRING = (hypo_np.unicode_string_dtypes,)
+
+    DATE = (partial(hypo_np.datetime64_dtypes, min_period='D', max_period='D'),)
+    YEAR = (partial(hypo_np.datetime64_dtypes, min_period='Y', max_period='Y'),)
+    YEAR_MONTH = (partial(hypo_np.datetime64_dtypes, min_period='M', max_period='M'),)
+    SECOND = (partial(hypo_np.datetime64_dtypes, min_period='s', max_period='s'),)
+    MILLISECOND = (partial(hypo_np.datetime64_dtypes, min_period='ms', max_period='ms'),)
+
+
+def get_dtype(dtype_group: DTGroup = DTGroup.ALL):
+
+    def st_dts():
+        for st_dt in dtype_group.value:
+            yield st_dt()
+
+    return st.one_of(st_dts())
+
+def get_dtypes(
+        min_size: int = 0,
+        dtype_group: DTGroup = DTGroup.ALL,
+        ) -> tp.Iterable[np.dtype]:
+    return st.lists(get_dtype(dtype_group), min_size=min_size)
+
+def get_dtype_pairs(
+        dtype_group: DTGroup = DTGroup.ALL,
+        ) -> tp.Tuple[np.dtype]:
+    return st.tuples(get_dtype(dtype_group), get_dtype(dtype_group))
+
+#-------------------------------------------------------------------------------
+# shape generation
+
+def get_shape_1d(min_size: int = 0, max_size: int = MAX_ROWS):
+    return st.tuples(st.integers(min_value=min_size, max_value=max_size))
+
+def get_shape_2d(
+        min_rows=1,
+        max_rows=MAX_ROWS,
+        min_columns=1,
+        max_columns=MAX_COLUMNS,
+        ):
+    return st.tuples(
+            st.integers(min_value=min_rows, max_value=max_rows),
+            st.integers(min_value=min_columns, max_value=max_columns)
+            )
+
+def get_shape_1d2d(
+        min_rows=1,
+        max_rows=MAX_ROWS,
+        min_columns=1,
+        max_columns=MAX_COLUMNS) -> tp.Union[tp.Tuple[int], tp.Tuple[int, int]]:
+
+    return st.one_of(
+            get_shape_2d(
+                    min_rows=min_rows,
+                    max_rows=max_rows,
+                    min_columns=min_columns,
+                    max_columns=max_columns),
+            get_shape_1d(
+                    min_size=min_rows,
+                    max_size=max_rows)
+            )
+
+#-------------------------------------------------------------------------------
+# array generation
+
+
+def get_array_1d(
+        min_size: int = 0,
+        max_size: int = MAX_ROWS,
+        unique: bool = False,
+        dtype_group: DTGroup = DTGroup.ALL
+        ):
+
+    if dtype_group == DTGroup.OBJECT:
+        return hypo_np.arrays(
+                get_dtype(dtype_group),
+                get_shape_1d(min_size=min_size, max_size=max_size),
+                elements=get_value(),
+                fill=st.nothing(), # force all values from elements
+                unique=unique
+                )
+
+    return hypo_np.arrays(
+            get_dtype(dtype_group),
+            get_shape_1d(min_size=min_size, max_size=max_size),
+            unique=unique
+            )
+
+get_array_1d_object = partial(get_array_1d, dtype_group=DTGroup.OBJECT)
+get_array_1d_object.__name__ = 'get_array_1d_object'
+
+
+def get_array_2d(
+        min_rows=1,
+        max_rows=MAX_ROWS,
+        min_columns=1,
+        max_columns=MAX_COLUMNS,
+        unique: bool = False,
+        dtype_group: DTGroup = DTGroup.ALL
+        ):
+
+    shape = get_shape_2d(
+            min_rows=min_rows,
+            max_rows=max_rows,
+            min_columns=min_columns,
+            max_columns=max_columns)
+
+    # TODO: identify object dtypes and populate with values
+
+    return hypo_np.arrays(
+            get_dtype(dtype_group),
+            shape=shape,
+            unique=unique)
+
+def get_array_1d2d(
+        min_rows=1,
+        max_rows=MAX_ROWS,
+        min_columns=1,
+        max_columns=MAX_COLUMNS,
+        dtype_group: DTGroup = DTGroup.ALL
+        ):
+    '''
+    For convenience in building blocks, treat row constraints as 1d size constraints.
+    '''
+    return st.one_of(
+            get_array_2d(min_rows=min_rows,
+                    max_rows=max_rows,
+                    min_columns=min_columns,
+                    max_columns=max_columns,
+                    dtype_group=dtype_group
+                    ),
+            get_array_1d(min_size=min_rows,
+                    max_size=max_rows,
+                    dtype_group=dtype_group
+                    )
+    )
+
+#-------------------------------------------------------------------------------
+# aligend arrays for concatenation and type blocks
+
+def get_arrays_2d_aligned_columns(min_size: int = 1, max_size: int = 10):
+
+    return st.integers(min_value=1, max_value=MAX_COLUMNS).flatmap(
+        lambda columns: st.lists(
+            get_array_2d(min_columns=columns, max_columns=columns),
+            min_size=min_size,
+            max_size=max_size
+            )
+    )
+
+def get_arrays_2d_aligned_rows(min_size: int = 1, max_size: int = 10):
+
+    return st.integers(min_value=1, max_value=MAX_ROWS).flatmap(
+        lambda rows: st.lists(
+            get_array_2d(min_rows=rows, max_rows=rows),
+            min_size=min_size,
+            max_size=max_size
+            )
+    )
+
+def get_blocks(
+        min_rows=1,
+        max_rows=MAX_ROWS,
+        min_columns=1,
+        max_columns=MAX_COLUMNS,
+        dtype_group=DTGroup.ALL
+        ):
+    '''
+    Args:
+        min_columns: number of resultant columns in combination of all arrays.
+    '''
+
+    def get_arrays(shape):
+        rows, columns = shape
+
+        def is_valid(blocks):
+            '''Filter to block combinations that sum to targetted columns
+            '''
+            return sum(1 if b.ndim == 1 else b.shape[1] for b in blocks) == columns
+
+        # have to use lists instead of iterables, as filter does an iteration
+        return st.lists(get_array_1d2d(
+                    min_rows=rows,
+                    max_rows=rows,
+                    min_columns=1,
+                    max_columns=columns,
+                    dtype_group=dtype_group
+                    ),
+                min_size=1,
+                max_size=columns
+                ).filter(is_valid)
+
+    return get_shape_2d(
+            min_rows=min_rows,
+            max_rows=max_rows,
+            min_columns=min_columns,
+            max_columns=max_columns).flatmap(get_arrays)
+
+
+def get_type_blocks(
+        min_rows=1,
+        max_rows=MAX_ROWS,
+        min_columns=1,
+        max_columns=MAX_COLUMNS,
+        dtype_group=DTGroup.ALL
+        ):
+    return st.builds(TypeBlocks.from_blocks,
+            get_blocks(min_rows=min_rows,
+                    max_rows=max_rows,
+                    min_columns=min_columns,
+                    max_columns=max_columns,
+                    dtype_group=dtype_group)
+            )
+
+
+get_type_blocks_numeric = partial(get_type_blocks, dtype_group=DTGroup.NUMERIC)
+get_type_blocks_numeric.__name__ = 'get_type_blocks_numeric'
+
+
+#-------------------------------------------------------------------------------
+# index objects
+
+def get_index(
+        min_size: int = 0,
+        max_size: int = MAX_ROWS,
+        dtype_group=None,
+        cls=Index):
+    # using get_labels here forces Index construction from lists, rather than from arrays
+    if dtype_group is not None:
+        return st.builds(cls, get_array_1d(
+                min_size=min_size,
+                max_size=max_size,
+                unique=True,
+                dtype_group=dtype_group
+                ))
+    return st.builds(cls, get_labels(min_size=min_size, max_size=max_size))
+
+get_index_date = partial(get_index, cls=IndexDate, dtype_group=DTGroup.DATE)
+get_index_date.__name__ = 'get_index_date'
+
+get_index_year = partial(get_index, cls=IndexYear, dtype_group=DTGroup.YEAR)
+get_index_year.__name__ = 'get_index_year'
+
+
+get_index_go = partial(get_index, cls=IndexGO)
+get_index_go.__name__ = 'get_index_go'
+
+
+
+#-------------------------------------------------------------------------------
+# series objects
+
+def get_series(min_size: int = 0,
+        max_size: int = MAX_ROWS,
+        cls=Series,
+        dtype_group=DTGroup.ALL,
+        index_cls=Index,
+        index_dtype_group=None
+        ):
+
+    def constructor(shape):
+        size = shape[0] # tuple len 1
+
+        index = get_index(
+                min_size=size,
+                max_size=size,
+                cls=index_cls,
+                dtype_group=index_dtype_group,
+                )
+
+        return st.builds(cls,
+            get_array_1d(
+                    min_size=size,
+                    max_size=size,
+                    dtype_group=dtype_group
+                    ),
+            index=index
+            )
+
+    return get_shape_1d().flatmap(constructor)
+
+# label index, values
+get_series_date_numeric = partial(get_series,
+        dtype_group=DTGroup.NUMERIC,
+        index_cls=IndexDate,
+        index_dtype_group=DTGroup.DATE
+        )
+get_series_date_numeric.__name__ = 'get_series_date_numeric'
+
+
+#-------------------------------------------------------------------------------
+# frames
+
+def get_frame(
+        min_rows=1,
+        max_rows=MAX_ROWS,
+        min_columns=1,
+        max_columns=MAX_COLUMNS,
+        cls=Frame,
+        dtype_group=DTGroup.ALL,
+        index_cls=Index,
+        index_dtype_group=None,
+        columns_cls=Index,
+        columns_dtype_group=None
+        ):
+
+    def constructor(shape):
+
+        row_count, column_count = shape
+
+        index = get_index(
+                min_size=row_count,
+                max_size=row_count,
+                cls=index_cls,
+                dtype_group=index_dtype_group,
+                )
+
+        columns = get_index(
+                min_size=column_count,
+                max_size=column_count,
+                cls=columns_cls,
+                dtype_group=columns_dtype_group,
+                )
+
+        return st.builds(cls,
+                get_type_blocks(
+                        min_rows=row_count,
+                        max_rows=row_count,
+                        min_columns=column_count,
+                        max_columns=column_count,
+                        dtype_group=dtype_group
+                        ),
+                index=index,
+                columns=columns
+                )
+
+    return get_shape_2d().flatmap(constructor)
+
+
+# label index, columns, values
+get_frame_date_str_numeric = partial(get_frame,
+        dtype_group=DTGroup.NUMERIC,
+        index_cls=IndexDate,
+        index_dtype_group=DTGroup.DATE,
+        columns_cls=Index,
+        columns_dtype_group=DTGroup.STRING
+        )
+get_frame_date_str_numeric.__name__ = 'get_frame_date_str_numeric'
+
+
+
+
+get_frame_go = partial(get_frame, cls=FrameGO)
+get_frame_go.__name__ = 'get_frame_go'
 
 
 
 
 
 if __name__ == '__main__':
-    from static_frame.core.display_color import HexColor
     import fnmatch
     import sys
     from argparse import ArgumentParser
+    from static_frame.core.display_color import HexColor
 
     parser = ArgumentParser()
     parser.add_argument('-n', '--name', default=None)
-    parser.add_argument('-c', '--count', default=3, type=int)
+    parser.add_argument('-c', '--count', default=2, type=int)
+
     options = parser.parse_args()
 
     local_items = tuple(locals().items())
@@ -218,7 +477,9 @@ if __name__ == '__main__':
 
         for x in range(options.count):
             print(HexColor.format_terminal('grey', '.' * 50))
-            print(v().example())
+            example = v().example()
+            print(repr(example))
+
 
 
 

--- a/static_frame/test/property/test_index.py
+++ b/static_frame/test/property/test_index.py
@@ -65,30 +65,18 @@ class TestUnit(TestCase):
         property_loc_to_iloc_element(Index, values)
         property_loc_to_iloc_element(IndexGO, values)
 
-
-    @given(get_labels())
+    @given(get_labels(min_size=1))
     def test_index_loc_to_iloc_slice(self, values):
 
         def property_loc_to_iloc_slice(cls, values):
             # Property: that the key translates to the appropriate slice.
             index = cls(values)
             for i, v in enumerate(values):
-                self.assertEqual(index.loc_to_iloc(slice(v, None)), slice(i, None))
-
-        property_loc_to_iloc_slice(Index, values)
-        property_loc_to_iloc_slice(IndexGO, values)
-
-
-    @given(get_labels(min_size=1))
-    def test_index_loc_to_iloc_slice(self, values):
-
-        def property_loc_to_iloc_slice(cls, values):
-            '''
-            Property: that the key translates to the appropriate slice.
-            '''
-            index = cls(values)
-            for i, v in enumerate(values):
-                self.assertEqual(index.loc_to_iloc(slice(v, None)), slice(i, None))
+                # insure that we get teh same slice going through loc that we would get by direct iloc
+                if v is None:
+                    self.assertEqual(index.loc_to_iloc(slice(v, None)), slice(None))
+                else:
+                    self.assertEqual(index.loc_to_iloc(slice(v, None)), slice(i, None))
 
         property_loc_to_iloc_slice(Index, values)
         property_loc_to_iloc_slice(IndexGO, values)

--- a/static_frame/test/property/test_util.py
+++ b/static_frame/test/property/test_util.py
@@ -16,6 +16,7 @@ from static_frame.test.property.strategies import get_dtype_pairs
 from static_frame.test.property.strategies import get_dtype
 from static_frame.test.property.strategies import get_dtypes
 from static_frame.test.property.strategies import get_label
+from static_frame.test.property.strategies import get_value
 from static_frame.test.property.strategies import get_labels
 from static_frame.test.property.strategies import get_arrays_2d_aligned_columns
 from static_frame.test.property.strategies import get_arrays_2d_aligned_rows
@@ -64,15 +65,14 @@ class TestUnit(TestCase):
         self.assertEqual(array.ndim, 2)
         self.assertEqual(array.dtype, util.resolve_dtype_iter((x.dtype for x in arrays)))
 
-    @given(get_dtype(), get_shape_1d2d(), get_label())
-    def test_full_or_fill(self, dtype, shape, label):
-        array = util.full_for_fill(dtype, shape, fill_value=label)
+    @given(get_dtype(), get_shape_1d2d(), get_value())
+    def test_full_or_fill(self, dtype, shape, value):
+        array = util.full_for_fill(dtype, shape, fill_value=value)
         self.assertTrue(array.shape == shape)
-        # import ipdb; ipdb.set_trace()
-        if isinstance(label, (float, complex)) and np.isnan(label):
+        if isinstance(value, (float, complex)) and np.isnan(value):
             pass
         else:
-            self.assertTrue(label in array)
+            self.assertTrue(value in array)
 
 if __name__ == '__main__':
     unittest.main()

--- a/static_frame/test/unit/test_index.py
+++ b/static_frame/test/unit/test_index.py
@@ -293,6 +293,15 @@ class TestUnit(TestCase):
                 [index.sort(ascending=False).loc_to_iloc(x) for x in sorted(index.values)],
                 [4, 3, 2, 1, 0])
 
+    def test_index_reversed(self):
+
+        labels = tuple('acdeb')
+        index = Index(labels=labels)
+        index_reversed_generator = reversed(index)
+        self.assertEqual(
+            tuple(index_reversed_generator),
+            tuple(reversed(labels))
+        )
 
     def test_index_relable(self):
 


### PR DESCRIPTION
In response to Issue https://github.com/InvestmentSystems/static-frame/issues/62, the following implements `__reversed__` for an Index and provides a unit test.  Assuming this PR is acceptable, I will complete the same for both a Series and a Frame.

Given that an Index has methods for both `__len__` and `__getitem__`, executing `reversed(Index)` will already work.  This PR, however, results in significantly faster execution of that function.