### PR TITLE
Removing one instance of package listed twice

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,5 @@ Pygments==2.2.0
 sphinx-jinja==0.3.0
 sphinxcontrib-napoleon==0.6.1
 sphinx_rtd_theme>=0.3.1
-sphinx-jinja==0.3.0
 hypothesis==3.71.3
 pandas==0.23.4


### PR DESCRIPTION
`sphinx-jinja==0.3.0` is listed twice in the `requirements-test.txt` file.  Possibly related to the build failure earlier, but certainly worth cleaning up in any case.