### PR TITLE
Series.__reversed__ / Frame.__reversed__

### DIFF
--- a/static_frame/core/frame.py
+++ b/static_frame/core/frame.py
@@ -1975,6 +1975,12 @@ class Frame(metaclass=MetaOperatorDelegate):
     #---------------------------------------------------------------------------
     # transformations resulting in the same dimensionality
 
+    def __reversed__(self) -> tp.Iterator[tp.Hashable]:
+        '''
+        Returns a reverse iterator on the frame's columns.
+        '''
+        return reversed(self._columns)
+
     def sort_index(self,
             ascending: bool = True,
             kind: str = DEFAULT_SORT_KIND) -> 'Frame':

--- a/static_frame/core/series.py
+++ b/static_frame/core/series.py
@@ -265,6 +265,13 @@ class Series(metaclass=MetaOperatorDelegate):
         if len(self.values) != shape:
             raise RuntimeError('values and index do not match length')
 
+    # ---------------------------------------------------------------------------
+    def __reversed__(self) -> tp.Iterator[tp.Hashable]:
+        '''
+        Returns a reverse iterator on the series' index.
+        '''
+        return reversed(self._index)
+
     #---------------------------------------------------------------------------
     def __setstate__(self, state):
         '''

--- a/static_frame/test/unit/test_frame.py
+++ b/static_frame/test/unit/test_frame.py
@@ -1830,6 +1830,20 @@ class TestUnit(TestCase):
                 ((('i', 'a'), (('a', 'a'), ('b', 'b'), ('c', 'c'))), (('i', 'b'), (('a', 'tru'), ('b', 'fals'), ('c', 'tru'))), (('ii', 'a'), (('a', 'non'), ('b', 'non'), ('c', 'non'))), (('ii', 'b'), (('a', 'non'), ('b', '1'), ('c', '5'))))
                 )
 
+    def test_frame_reversed(self):
+        columns = tuple('pqrst')
+        index = tuple('zxwy')
+        records = ((2, 2, 'a', False, False),
+                   (30, 34, 'b', True, False),
+                   (2, 95, 'c', False, False),
+                   (30, 73, 'd', True, True))
+
+        f = Frame.from_records(
+                records, columns=columns, index=index,name='foo')
+
+        self.assertTrue(tuple(reversed(f)) == tuple(reversed(columns)))
+
+
     def test_frame_sort_index_a(self):
         # reindex both axis
         records = (

--- a/static_frame/test/unit/test_series.py
+++ b/static_frame/test/unit/test_series.py
@@ -999,6 +999,13 @@ class TestUnit(TestCase):
         self.assertEqual(s3.name, s1.name)
 
 
+    def test_series_reversed(self):
+
+        idx = tuple('abcd')
+        s = Series(range(4), index=idx)
+        self.assertTrue(tuple(reversed(s)) == tuple(reversed(idx)))
+
+
     def test_series_relabel_a(self):
 
         s1 = Series(range(4), index=('a', 'b', 'c', 'd'))


### PR DESCRIPTION
A continuation of PR https://github.com/InvestmentSystems/static-frame/pull/66 (responding to Issue https://github.com/InvestmentSystems/static-frame/issues/62), the following implements` __reversed__` for both a Series and a Frame and provides unit tests. 