### PR TITLE
IndexBase.__reversed__

### DIFF
--- a/static_frame/core/index_base.py
+++ b/static_frame/core/index_base.py
@@ -174,6 +174,14 @@ class IndexBase:
             self._update_array_cache()
         return self._labels.__iter__()
 
+    def __reversed__(self) -> tp.Iterable[tp.Hashable]:
+        '''
+        Returns a reverse iterator on the index labels.
+        '''
+        if self._recache:
+            self._update_array_cache()
+        return reversed(self._labels)
+
     #---------------------------------------------------------------------------
     # common display
 

--- a/static_frame/test/unit/test_index.py
+++ b/static_frame/test/unit/test_index.py
@@ -293,6 +293,15 @@ class TestUnit(TestCase):
                 [index.sort(ascending=False).loc_to_iloc(x) for x in sorted(index.values)],
                 [4, 3, 2, 1, 0])
 
+    def test_index_reversed(self):
+
+        labels = tuple('acdeb')
+        index = Index(labels=labels)
+        index_reversed_generator = reversed(index)
+        self.assertEqual(
+            tuple(index_reversed_generator),
+            tuple(reversed(labels))
+        )
 
     def test_index_relable(self):
 

--- a/static_frame/test/unit/test_index_hierarchy.py
+++ b/static_frame/test/unit/test_index_hierarchy.py
@@ -411,6 +411,15 @@ class TestUnit(TestCase):
                 )
 
 
+    def test_hierarchy_reversed(self):
+        labels = (('a', 1), ('a', 2), ('b', 1), ('b', 2))
+        hier_idx = IndexHierarchy.from_labels(labels)
+        self.assertTrue(
+            all(tuple(hidx_1) == hidx_2
+                for hidx_1, hidx_2 in zip(reversed(hier_idx), reversed(labels)))
+        )
+
+
     def test_hierarchy_keys_a(self):
         OD = OrderedDict
         tree = OD([


### PR DESCRIPTION
As requested, this PR implements `__reversed__` in the `IndexBase` base class.

I messed up my rebase on the original branch, so I just deleted it and created a new one.  Here is the conversation history from the original branch. https://github.com/InvestmentSystems/static-frame/pull/66