### PR TITLE
Fix Frame and Series from_pandas() pandas >1.0.0 issues

### DIFF
--- a/static_frame/core/frame.py
+++ b/static_frame/core/frame.py
@@ -1718,13 +1718,15 @@ class Frame(ContainerOperand):
         # create generator of contiguous typed data
         # calling .values will force type unification accross all columns
         def blocks():
+            from pandas.core.dtypes.common import is_dtype_equal
+
             pairs = value.dtypes.items()
             column_start, dtype_current = next(pairs)
 
             column_last = column_start
             for column, dtype in pairs:
 
-                if dtype != dtype_current:
+                if is_dtype_equal(dtype, dtype_current):
                     # use loc to select before calling .values
                     array = value.loc[NULL_SLICE,
                             slice(column_start, column_last)].values

--- a/static_frame/core/util.py
+++ b/static_frame/core/util.py
@@ -240,9 +240,12 @@ def mloc(array: np.ndarray) -> int:
     return tp.cast(int, array.__array_interface__['data'][0])
 
 
-def immutable_filter(src_array: np.ndarray) -> np.ndarray:
+def immutable_filter(src_array: tp.Union[np.ndarray, 'pandas.PandasArray']) -> np.ndarray:
     '''Pass an immutable array; otherwise, return an immutable copy of the provided array.
     '''
+    if hasattr(src_array, 'to_numpy'):  # is pandas.core.arrays.base.ExtensionArray
+        src_array = src_array.to_numpy(copy=True)
+        src_array.flags.writeable = False
     if src_array.flags.writeable:
         dst_array = src_array.copy()
         dst_array.flags.writeable = False

--- a/static_frame/test/unit/test_frame.py
+++ b/static_frame/test/unit/test_frame.py
@@ -526,6 +526,19 @@ class TestUnit(TestCase):
 
         self.assertEqual(f._blocks.shapes.tolist(), [(2, 2)])
 
+    def test_frame_from_pandas_f(self) -> None:
+        import pandas as pd
+
+        df = pd.DataFrame(dict(a=(1,2), b=('3','4'), c=(1.5,2.5), d=('a','b'))).convert_dtypes()
+        df.name = 'foo'
+
+        f = Frame.from_pandas(df)
+        self.assertEqual(f.to_pairs(0),
+                (('a', ((0, 1), (1, 2))),
+                 ('b', ((0, '3'), (1, '4'))),
+                 ('c', ((0, 1.5), (1, 2.5))),
+                 ('d', ((0, 'a'), (1, 'b'))))
+                )
 
     #---------------------------------------------------------------------------
 

--- a/static_frame/test/unit/test_series.py
+++ b/static_frame/test/unit/test_series.py
@@ -1732,6 +1732,22 @@ class TestUnit(TestCase):
         sfs = Series.from_pandas(pds, own_data=True)
         self.assertEqual(list(pds.items()), list(sfs.items()))
 
+    def test_series_from_pandas_b(self) -> None:
+        import pandas as pd
+
+        pds = pd.Series([3,4,5], index=list('abc')).convert_dtypes()
+        sfs = Series.from_pandas(pds)
+        self.assertEqual(list(pds.items()), list(sfs.items()))
+
+        # mutate Pandas
+        pds['c'] = 50
+        self.assertNotEqual(pds['c'], sfs['c'])
+
+        # owning data
+        pds = pd.Series([3,4,5], index=list('abc'))
+        sfs = Series.from_pandas(pds, own_data=True)
+        self.assertEqual(list(pds.items()), list(sfs.items()))
+
     def test_series_to_pandas_a(self) -> None:
 
         s1 = Series(range(4),


### PR DESCRIPTION
It might hit performance, but it seems the safest way to support pandas 1.0.0 ExtensionArray.