### PR TITLE
Issue #118: Adds index difference method

### DIFF
--- a/static_frame/core/index.py
+++ b/static_frame/core/index.py
@@ -42,6 +42,7 @@ from static_frame.core.selector_node import InterfaceGetItem
 from static_frame.core.selector_node import InterfaceSelection1D
 from static_frame.core.util import union1d
 from static_frame.core.util import intersect1d
+from static_frame.core.util import setdiff1d
 from static_frame.core.util import to_datetime64
 from static_frame.core.util import INT_TYPES
 
@@ -292,6 +293,7 @@ class Index(IndexBase):
 
     _UFUNC_UNION = union1d
     _UFUNC_INTERSECTION = intersect1d
+    _UFUNC_DIFFERENCE = setdiff1d
 
     _DTYPE: tp.Optional[np.dtype] = None # for specialized indices requiring a typed labels
 

--- a/static_frame/core/index_base.py
+++ b/static_frame/core/index_base.py
@@ -82,6 +82,7 @@ class IndexBase(ContainerOperand):
 
     _UFUNC_UNION: tp.Callable[[np.ndarray, np.ndarray, bool], np.ndarray]
     _UFUNC_INTERSECTION: tp.Callable[[np.ndarray, np.ndarray, bool], np.ndarray]
+    _UFUNC_DIFFERENCE: tp.Callable[[np.ndarray, np.ndarray, bool], np.ndarray]
 
     label_widths_at_depth: tp.Callable[[I, int], tp.Iterator[tp.Tuple[tp.Hashable, int]]]
 
@@ -345,6 +346,13 @@ class IndexBase(ContainerOperand):
                 self.__class__._UFUNC_UNION,
                 other)
 
+    def difference(self: I, other: 'IndexBase') -> I:
+        '''
+        Perform difference with another Index, container, or NumPy array. Retains order.
+        '''
+        return self._ufunc_set(
+                self.__class__._UFUNC_DIFFERENCE,
+                other)
 
     #---------------------------------------------------------------------------
     # metaclass-applied functions

--- a/static_frame/core/index_hierarchy.py
+++ b/static_frame/core/index_hierarchy.py
@@ -21,6 +21,7 @@ from static_frame.core.util import GetItemKeyType
 from static_frame.core.util import NULL_SLICE
 from static_frame.core.util import intersect2d
 from static_frame.core.util import union2d
+from static_frame.core.util import setdiff2d
 from static_frame.core.util import array2d_to_tuples
 from static_frame.core.util import name_filter
 from static_frame.core.util import isin
@@ -102,6 +103,7 @@ class IndexHierarchy(IndexBase):
 
     _UFUNC_UNION = union2d
     _UFUNC_INTERSECTION = intersect2d
+    _UFUNC_DIFFERENCE = setdiff2d
 
     #---------------------------------------------------------------------------
     # constructors

--- a/static_frame/core/util.py
+++ b/static_frame/core/util.py
@@ -1425,8 +1425,6 @@ def _ufunc_set_1d(
     elif is_difference:
         if len(array) == 0:
             return np.array(EMPTY_TUPLE, dtype=dtype)
-        elif len(other) == 0:
-            return array
 
     if assume_unique:
         # can only return arguments, and use length to determine unique comparison condition, if arguments are assumed to already be unique
@@ -1434,6 +1432,9 @@ def _ufunc_set_1d(
             if len(array) == 0:
                 return other
             elif len(other) == 0:
+                return array
+        elif is_difference:
+            if len(other) == 0:
                 return array
 
         if len(array) == len(other):
@@ -1510,8 +1511,6 @@ def _ufunc_set_2d(
     elif is_difference:
         if len(array) == 0:
             return np.array(EMPTY_TUPLE, dtype=dtype)
-        elif len(other) == 0:
-            return array
 
     if assume_unique:
         # can only return arguments, and use length to determine unique comparison condition, if arguments are assumed to already be unique
@@ -1519,6 +1518,9 @@ def _ufunc_set_2d(
             if len(array) == 0:
                 return other
             elif len(other) == 0:
+                return array
+        elif is_difference:
+            if len(other) == 0:
                 return array
 
         if array.shape == other.shape:

--- a/static_frame/core/util.py
+++ b/static_frame/core/util.py
@@ -1408,20 +1408,25 @@ def _ufunc_set_1d(
     Args:
         assume_unique: if arguments are assumed unique, can implement optional identity filtering, which retains order (un sorted) for opperands that are equal. This is important in numerous operations on the matching Indices where order should not be perterbed.
     '''
-    if func == np.intersect1d:
-        is_union = False
-    elif func == np.union1d:
-        is_union = True
-    else:
+    is_union = func == np.union1d
+    is_intersection = func == np.intersect1d
+    is_difference = func == np.setdiff1d
+
+    if not (is_union or is_intersection or is_difference):
         raise NotImplementedError('unexpected func', func)
 
     dtype = resolve_dtype(array.dtype, other.dtype)
 
     # optimizations for empty arrays
-    if not is_union: # intersection with empty
+    if is_intersection:
         if len(array) == 0 or len(other) == 0:
             # not sure what DTYPE is correct to return here
             return np.array(EMPTY_TUPLE, dtype=dtype)
+    elif is_difference:
+        if len(array) == 0:
+            return np.array(EMPTY_TUPLE, dtype=dtype)
+        elif len(other) == 0:
+            return array
 
     if assume_unique:
         # can only return arguments, and use length to determine unique comparison condition, if arguments are assumed to already be unique
@@ -1432,12 +1437,20 @@ def _ufunc_set_1d(
                 return array
 
         if len(array) == len(other):
+            arrays_are_equal = False
             compare = array == other
-            # if sizes are the same, the result of == is mostly length 2; comparison to some arrays (i.e., string), will result in a single Boolean, but it should always be False
+
+            # if sizes are the same, the result of == is mostly a bool array; comparison to some arrays (e.g. string), will result in a single Boolean, but it should always be False
             if isinstance(compare, BOOL_TYPES) and compare:
-                return array #pragma: no cover
+                arrays_are_equal = True
             elif isinstance(compare, np.ndarray) and compare.all(axis=None):
-                return array
+                arrays_are_equal = True
+
+            if arrays_are_equal:
+                if is_difference:
+                    return np.array(EMPTY_TUPLE, dtype=dtype)
+                else:
+                    return array #pragma: no cover
 
     set_compare = False
     array_is_str = array.dtype.kind in DTYPE_STR_KIND
@@ -1450,13 +1463,16 @@ def _ufunc_set_1d(
     if set_compare or dtype.kind == 'O':
         if is_union:
             result = frozenset(array) | frozenset(other)
-        else:
+        elif is_intersection:
             result = frozenset(array) & frozenset(other)
+        else:
+            result = frozenset(array).difference(frozenset(other))
+
         v, _ = iterable_to_array_1d(result, dtype)
         return v
 
-    return func(array, other)
-
+    func_kwargs = {} if is_union else dict(assume_unique=assume_unique)
+    return func(array, other, **func_kwargs)
 
 def _ufunc_set_2d(
         func: tp.Callable[[np.ndarray, np.ndarray], np.ndarray],
@@ -1476,21 +1492,26 @@ def _ufunc_set_2d(
     Returns:
         Either a 2D array, or a 1D object array of tuples.
     '''
-    if func == np.intersect1d:
-        is_union = False
-    elif func == np.union1d:
-        is_union = True
-    else:
+    is_union = func == np.union1d
+    is_intersection = func == np.intersect1d
+    is_difference = func == np.setdiff1d
+
+    if not (is_union or is_intersection or is_difference):
         raise NotImplementedError('unexpected func', func)
 
     # if either are object, or combination resovle to object, get object
     dtype = resolve_dtype(array.dtype, other.dtype)
 
     # optimizations for empty arrays
-    if not is_union: # intersection with empty
+    if is_intersection: # intersection with empty
         if len(array) == 0 or len(other) == 0:
             # not sure what DTYPE is correct to return here
             return np.array(EMPTY_TUPLE, dtype=dtype)
+    elif is_difference:
+        if len(array) == 0:
+            return np.array(EMPTY_TUPLE, dtype=dtype)
+        elif len(other) == 0:
+            return array
 
     if assume_unique:
         # can only return arguments, and use length to determine unique comparison condition, if arguments are assumed to already be unique
@@ -1500,13 +1521,21 @@ def _ufunc_set_2d(
             elif len(other) == 0:
                 return array
 
-        # will not match a 2D array of integers and 1D array of tuples containing integers (would have to do a post-set comparison, but would loose order)
         if array.shape == other.shape:
+            arrays_are_equal = False
             compare = array == other
+
+            # will not match a 2D array of integers and 1D array of tuples containing integers (would have to do a post-set comparison, but would loose order)
             if isinstance(compare, BOOL_TYPES) and compare:
-                return array
+                arrays_are_equal = True
             elif isinstance(compare, np.ndarray) and compare.all(axis=None):
-                return array
+                arrays_are_equal = True
+
+            if arrays_are_equal:
+                if is_difference:
+                    return np.array(EMPTY_TUPLE, dtype=dtype)
+                else:
+                    return array
 
     if dtype.kind == 'O':
         # assume that 1D arrays arrays are arrays of tuples
@@ -1522,8 +1551,10 @@ def _ufunc_set_2d(
 
         if is_union:
             result = array_set | other_set
-        else:
+        elif is_intersection:
             result = array_set & other_set
+        else:
+            result = array_set.difference(other_set)
 
         # NOTE: this sort may not always be succesful
         try:
@@ -1549,9 +1580,11 @@ def _ufunc_set_2d(
     if other.dtype != dtype:
         other = other.astype(dtype)
 
+    func_kwargs = {} if is_union else dict(assume_unique=assume_unique)
+
     if width == 1:
         # let the function flatten the array, then reshape into 2D
-        post = func(array, other)
+        post = func(array, other, **func_kwargs)
         return post.reshape(len(post), width)
 
     # this approach based on https://stackoverflow.com/questions/9269681/intersection-of-2d-numpy-ndarrays
@@ -1562,7 +1595,7 @@ def _ufunc_set_2d(
     array_view = array.view(dtype_view)
     other_view = other.view(dtype_view)
 
-    return func(array_view, other_view).view(dtype).reshape(-1, width)
+    return func(array_view, other_view, **func_kwargs).view(dtype).reshape(-1, width)
 
 
 def union1d(array: np.ndarray,
@@ -1590,7 +1623,21 @@ def intersect1d(
             other,
             assume_unique=assume_unique)
 
-def union2d(array: np.ndarray,
+def setdiff1d(
+        array: np.ndarray,
+        other: np.ndarray,
+        assume_unique: bool=False
+        ) -> np.ndarray:
+    '''
+    Difference on 1D array, handling diverse types and short-circuiting to preserve order where appropriate
+    '''
+    return _ufunc_set_1d(np.setdiff1d,
+        array,
+        other,
+        assume_unique=assume_unique)
+
+def union2d(
+        array: np.ndarray,
         other: np.ndarray,
         *,
         assume_unique: bool=False
@@ -1603,7 +1650,8 @@ def union2d(array: np.ndarray,
             other,
             assume_unique=assume_unique)
 
-def intersect2d(array: np.ndarray,
+def intersect2d(
+        array: np.ndarray,
         other: np.ndarray,
         *,
         assume_unique: bool=False
@@ -1616,6 +1664,19 @@ def intersect2d(array: np.ndarray,
             other,
             assume_unique=assume_unique)
 
+def setdiff2d(
+        array: np.ndarray,
+        other: np.ndarray,
+        *,
+        assume_unique: bool=False
+        ) -> np.ndarray:
+    '''
+    Difference on 2D array, handling diverse types and short-circuiting to preserve order where appropriate.
+    '''
+    return _ufunc_set_2d(np.setdiff1d,
+        array,
+        other,
+        assume_unique=assume_unique)
 
 def ufunc_set_iter(
         arrays: tp.Iterable[np.ndarray],

--- a/static_frame/core/util.py
+++ b/static_frame/core/util.py
@@ -234,6 +234,15 @@ YearMonthInitializer = tp.Union[str, datetime.date, np.datetime64]
 YearInitializer = tp.Union[str, datetime.date, np.datetime64]
 
 
+class NpOperator1dFuncType(tp.Protocol):
+    def __call__(self,
+            array: np.ndarray,
+            other: np.ndarray,
+            *,
+            assume_unique: bool=False
+        ) -> np.ndarray:
+        pass
+
 #-------------------------------------------------------------------------------
 
 def is_hashable(value: tp.Any) -> bool:
@@ -1396,7 +1405,7 @@ def array2d_to_tuples(array: np.ndarray) -> tp.Iterator[tp.Tuple[tp.Any, ...]]:
 # extension to union and intersection handling
 
 def _ufunc_set_1d(
-        func: tp.Callable[[np.ndarray, np.ndarray], np.ndarray],
+        func: NpOperator1dFuncType,
         array: np.ndarray,
         other: np.ndarray,
         *,
@@ -1476,7 +1485,7 @@ def _ufunc_set_1d(
     return func(array, other, **func_kwargs)
 
 def _ufunc_set_2d(
-        func: tp.Callable[[np.ndarray, np.ndarray], np.ndarray],
+        func: NpOperator1dFuncType,
         array: np.ndarray,
         other: np.ndarray,
         *,

--- a/static_frame/test/property/test_util.py
+++ b/static_frame/test/property/test_util.py
@@ -302,14 +302,13 @@ class TestUnit(TestCase):
         # complex results are tricky to compare after forming sets
         if (post.dtype.kind not in ('O', 'M', 'm', 'c', 'f')
                 and not np.isnan(post).any()):
-            self.assertTrue(set(post) == (set(arrays[0]) | set(arrays[1])))
+            self.assertSetEqual(set(post), (set(arrays[0]) | set(arrays[1])))
 
 
     @given(st.lists(get_array_1d(), min_size=2, max_size=2)) # type: ignore
     def test_intersect1d(self, arrays: tp.Sequence[np.ndarray]) -> None:
         post = util.intersect1d(
                 arrays[0],
-
                 arrays[1],
                 assume_unique=False)
         self.assertTrue(post.ndim == 1)
@@ -318,7 +317,23 @@ class TestUnit(TestCase):
 
         if (post.dtype.kind not in ('O', 'M', 'm', 'c', 'f')
                 and not np.isnan(post).any()):
-            self.assertTrue(set(post) == (set(arrays[0]) & set(arrays[1])))
+            self.assertSetEqual(set(post), (set(arrays[0]) & set(arrays[1])))
+
+
+    @given(st.lists(get_array_1d(), min_size=2, max_size=2)) # type: ignore
+    def test_setdiff1d(self, arrays: tp.Sequence[np.ndarray]) -> None:
+        post = util.setdiff1d(
+                arrays[0],
+                arrays[1],
+                assume_unique=False)
+        self.assertTrue(post.ndim == 1)
+
+        # nan values in complex numbers make direct comparison tricky
+        self.assertTrue(len(post) == len(set(arrays[0]).difference(set(arrays[1]))))
+
+        if (post.dtype.kind not in ('O', 'M', 'm', 'c', 'f')
+                and not np.isnan(post).any()):
+            self.assertSetEqual(set(post), (set(arrays[0]).difference(set(arrays[1]))))
 
 
     @given(get_arrays_2d_aligned_columns(min_size=2, max_size=2)) # type: ignore
@@ -348,6 +363,18 @@ class TestUnit(TestCase):
                 & set(util.array2d_to_tuples(arrays[1])))
                 )
 
+    @given(get_arrays_2d_aligned_columns(min_size=2, max_size=2)) # type: ignore
+    def test_setdiff2d(self, arrays: tp.Sequence[np.ndarray]) -> None:
+        post = util.setdiff2d(arrays[0], arrays[1], assume_unique=False)
+        if post.dtype == object:
+            self.assertTrue(post.ndim == 1)
+        else:
+            self.assertTrue(post.ndim == 2)
+
+        self.assertTrue(len(post) == len(
+                set(util.array2d_to_tuples(arrays[0])).difference(
+                set(util.array2d_to_tuples(arrays[1]))))
+                )
 
     @given(get_arrays_2d_aligned_columns()) # type: ignore
     def test_array_set_ufunc_many(self, arrays: tp.Sequence[np.ndarray]) -> None:

--- a/static_frame/test/unit/test_index.py
+++ b/static_frame/test/unit/test_index.py
@@ -896,7 +896,7 @@ class TestUnit(TestCase):
 
     def test_index_difference_c(self) -> None:
         obj = object()
-        idx1 = Index((1, None, '3', np.nan, 4.4, obj))
+        idx1 = Index((1, None, '3', np.nan, 4.4, obj)) # type: ignore
         idx2 = Index((2, 3, '4', 'five', 6.6, object()))
 
         idx3 = idx1.difference(idx2)
@@ -906,7 +906,7 @@ class TestUnit(TestCase):
 
     def test_index_difference_d(self) -> None:
         obj = object()
-        idx1 = Index((1, None, '3', np.nan, 4.4, obj))
+        idx1 = Index((1, None, '3', np.nan, 4.4, obj)) # type: ignore
         idx2 = Index((2, 1, '3', 'five', object()))
 
         idx3 = idx1.difference(idx2)

--- a/static_frame/test/unit/test_index.py
+++ b/static_frame/test/unit/test_index.py
@@ -872,6 +872,48 @@ class TestUnit(TestCase):
                 ['c', 'b', 'a']
                 )
 
+    def test_index_difference_a(self) -> None:
+        idx1 = Index(('c', 'b', 'a'))
+        idx2 = Index(('c', 'b', 'a'))
+
+        idx3 = idx1.difference(idx2)
+        self.assertEqual(idx3.values.tolist(), [])
+
+    def test_index_difference_b(self) -> None:
+        idx1 = Index(())
+        idx2 = Index(('c', 'b', 'a'))
+
+        idx3 = idx1.difference(idx2)
+        self.assertEqual(idx3.values.tolist(), [])
+
+        idx4 = Index(('c', 'b', 'a'))
+        idx5 = Index(())
+
+        idx6 = idx4.difference(idx5)
+        self.assertEqual(idx6.values.tolist(),
+                ['c', 'b', 'a']
+                )
+
+    def test_index_difference_c(self) -> None:
+        obj = object()
+        idx1 = Index((1, None, '3', np.nan, 4.4, obj))
+        idx2 = Index((2, 3, '4', 'five', 6.6, object()))
+
+        idx3 = idx1.difference(idx2)
+        self.assertEqual(set(idx3.values.tolist()),
+                set([np.nan, 1, 4.4, obj, '3', None])
+                ) # Note: order is lost...
+
+    def test_index_difference_d(self) -> None:
+        obj = object()
+        idx1 = Index((1, None, '3', np.nan, 4.4, obj))
+        idx2 = Index((2, 1, '3', 'five', object()))
+
+        idx3 = idx1.difference(idx2)
+        self.assertEqual(set(idx3.values.tolist()),
+                set([np.nan, None, 4.4, obj])
+                ) # Note: order is lost...
+
 
 
     def test_index_to_html_a(self) -> None:

--- a/static_frame/test/unit/test_index_hierarchy.py
+++ b/static_frame/test/unit/test_index_hierarchy.py
@@ -1011,7 +1011,7 @@ class TestUnit(TestCase):
             ih1.rehierarch([0,])
 
 
-    def test_hierarchy_intersection_a(self) -> None:
+    def test_hierarchy_set_operators_a(self) -> None:
 
         labels = (
                 ('I', 'A'),
@@ -1031,17 +1031,20 @@ class TestUnit(TestCase):
 
         ih2 = IndexHierarchy.from_labels(labels)
 
-        post = ih1.intersection(ih2)
-        self.assertEqual(post.values.tolist(),
+        post1 = ih1.intersection(ih2)
+        self.assertEqual(post1.values.tolist(),
                 [['II', 'A'], ['II', 'B']])
 
-        post = ih1.union(ih2)
-        self.assertEqual(post.values.tolist(),
+        post2 = ih1.union(ih2)
+        self.assertEqual(post2.values.tolist(),
                 [['I', 'A'], ['I', 'B'], ['II', 'A'], ['II', 'B'], ['III', 'A'], ['III', 'B']])
 
+        post3 = ih1.difference(ih2)
+        self.assertEqual(post3.values.tolist(),
+                [['I', 'A'], ['I', 'B']])
 
 
-    def test_hierarchy_intersection_b(self) -> None:
+    def test_hierarchy_set_operators_b(self) -> None:
 
         labels = (
                 ('II', 'B'),
@@ -1055,12 +1058,65 @@ class TestUnit(TestCase):
 
         post1 = ih1.union(ih2)
         self.assertEqual(post1.values.tolist(),
-            [['II', 'B'], ['II', 'A'], ['I', 'B'], ['I', 'A']])
+                [['II', 'B'], ['II', 'A'], ['I', 'B'], ['I', 'A']])
 
         post2 = ih1.intersection(ih2)
         self.assertEqual(post2.values.tolist(),
-            [['II', 'B'], ['II', 'A'], ['I', 'B'], ['I', 'A']])
+                [['II', 'B'], ['II', 'A'], ['I', 'B'], ['I', 'A']])
 
+        post3 = ih1.difference(ih2)
+        self.assertEqual(post3.values.tolist(),
+                [])
+
+
+    def test_hierarchy_set_operators_c(self) -> None:
+
+        labels = (
+                ('II', 'B'),
+                ('II', 'A'),
+                ('I', 'B'),
+                ('I', 'A'),
+                )
+
+        ih1 = IndexHierarchy.from_labels(())
+        ih2 = IndexHierarchy.from_labels(labels)
+
+        post1 = ih1.union(ih2)
+        self.assertEqual(post1.values.tolist(),
+                [['II', 'B'], ['II', 'A'], ['I', 'B'], ['I', 'A']])
+
+        post2 = ih1.intersection(ih2)
+        self.assertEqual(post2.values.tolist(),
+                [])
+
+        post3 = ih1.difference(ih2)
+        self.assertEqual(post3.values.tolist(),
+                [])
+
+
+    def test_hierarchy_set_operators_d(self) -> None:
+
+        labels = (
+                ('II', 'B'),
+                ('II', 'A'),
+                ('I', 'B'),
+                ('I', 'A'),
+                )
+
+        ih1 = IndexHierarchy.from_labels(labels)
+        ih2 = IndexHierarchy.from_labels(())
+
+        post1 = ih1.union(ih2)
+        self.assertEqual(post1.values.tolist(),
+                [['II', 'B'], ['II', 'A'], ['I', 'B'], ['I', 'A']])
+
+        post2 = ih1.intersection(ih2)
+        self.assertEqual(post2.values.tolist(),
+                [])
+
+        post3 = ih1.difference(ih2)
+        self.assertEqual(post3.values.tolist(),
+                [['II', 'B'], ['II', 'A'], ['I', 'B'], ['I', 'A']])
 
     #---------------------------------------------------------------------------
 

--- a/static_frame/test/unit/test_util.py
+++ b/static_frame/test/unit/test_util.py
@@ -14,6 +14,7 @@ from static_frame.core.util import ufunc_set_iter
 
 from static_frame.core.util import intersect2d
 from static_frame.core.util import union2d
+from static_frame.core.util import setdiff2d
 from static_frame.core.util import concat_resolved
 from static_frame.core.util import _isin_1d
 from static_frame.core.util import _isin_2d
@@ -41,6 +42,7 @@ from static_frame.core.util import roll_2d
 
 from static_frame.core.util import union1d
 from static_frame.core.util import intersect1d
+from static_frame.core.util import setdiff1d
 
 from static_frame.core.util import to_datetime64
 from static_frame.core.util import _DT64_YEAR
@@ -550,6 +552,64 @@ class TestUnit(TestCase):
         self.assertEqual(post.tolist(),
                 [(0, 1), (0, 3)])
 
+    def test_setdiff1d_a(self) -> None:
+        a1 = np.array([3, 2, 1])
+        a2 = np.array(['3', '2', '1'])
+        self.assertSetEqual(set(setdiff1d(a1, a2)), {3, 2, 1})
+
+        a3 = np.array(['a', 'b', 'c'])
+        a4 = np.array(['aaa', 'bbb', 'ccc'])
+        self.assertSetEqual(set(setdiff1d(a3, a4)), {'a', 'b', 'c'})
+
+        a5 = np.array([1, 2, 3])
+        a6 = np.array([None, False])
+        self.assertSetEqual(set(setdiff1d(a5, a6)), {1, 2, 3})
+
+        a7 = np.array([False, True])
+        a8 = np.array([None, 'a'])
+        self.assertSetEqual(set(setdiff1d(a7, a8)), {False, True})
+
+        a9 = np.array([None, 1, 'd'])
+        a10 = np.array([None, 3, 'ff'])
+        self.assertSetEqual(set(setdiff1d(a9, a10)), {1, 'd'})
+
+        a11 = np.array([False, True, False])
+        a12 = np.array([2, 3])
+        self.assertSetEqual(set(setdiff1d(a11, a12)), {False, True})
+
+
+    def test_setdiff1d_b(self) -> None:
+        a1 = np.array([])
+        a2 = np.array([9007199254740993], dtype=np.uint64)
+        self.assertEqual(setdiff1d(a1, a2).tolist(), [])
+        self.assertEqual(setdiff1d(a2, a1).tolist(), [9007199254740993])
+
+
+    def test_setdiff1d_c(self) -> None:
+        a1 = np.array([3, 2, 1])
+        a2 = np.array(['3', 2, '1'], dtype=object)
+        self.assertSetEqual(set(setdiff1d(a1, a2)), {3, 1})
+
+        a3 = np.array(['aaa', 'b', 'ccc'])
+        a4 = np.array(['aaa', 'bbb', 'ccc'])
+        self.assertSetEqual(set(setdiff1d(a3, a4)), {'b'})
+
+        a5 = np.array([None, 2, 3])
+        a6 = np.array([None, False])
+        self.assertSetEqual(set(setdiff1d(a5, a6)), {2, 3})
+
+        a7 = np.array([False, True])
+        a8 = np.array([None, 'a', True])
+        self.assertSetEqual(set(setdiff1d(a7, a8)), {False})
+
+        obj = object()
+        a9 = np.array([None, obj, 'd'])
+        a10 = np.array([obj, None, 'ff'])
+        self.assertSetEqual(set(setdiff1d(a9, a10)), {'d'})
+
+        a11 = np.array([False, np.nan, False], dtype=object)
+        a12 = np.array([False, None])
+        self.assertSetEqual(set(setdiff1d(a11, a12)), {np.nan})
 
 
     def test_union2d_a(self) -> None:
@@ -649,6 +709,44 @@ class TestUnit(TestCase):
                 set(((3, 1),))
                 )
 
+    def test_setdiff2d_a(self) -> None:
+        a1 = np.array([[3, 1], [0, 1]])
+        a2 = np.array([[3, 1], [0, 1]])
+
+        post1 = setdiff2d(a1, a2, assume_unique=True)
+        self.assertEqual(post1.tolist(),
+                [])
+
+    def test_setdiff2d_b(self) -> None:
+        a1 = np.array([[3, 1], [0, 1]])
+        a2 = np.array([['3', '1'], ['0', '1']])
+
+        post1 = setdiff2d(a1, a2, assume_unique=True)
+        self.assertEqual(
+                set(tuple(x) for x in post1),
+                set(((0, 1), (3, 1)))
+                )
+
+    def test_setdiff2d_c(self) -> None:
+        a1 = np.array([[3, 1], [0, 1]])
+        a2 = np.array([[3, 1], [10, 20]])
+
+        post1 = setdiff2d(a1, a2, assume_unique=True)
+        self.assertEqual(
+                set(tuple(x) for x in post1),
+                set(((0, 1),))
+                )
+
+    def test_setdiff2d_d(self) -> None:
+        a1 = np.array([None, None], dtype=object)
+        a1[:] = ((3, 1), (20, 10))
+        a2 = np.array([[3, 1], [10, 20]])
+
+        post1 = setdiff2d(a1, a2, assume_unique=True)
+        self.assertEqual(
+                set(tuple(x) for x in post1),
+                set(((20, 10),))
+                )
 
     #---------------------------------------------------------------------------
     def test_isin_non_empty(self) -> None:


### PR DESCRIPTION
Adds logic to handle index differences. (Implements feature request #118)

The only change to the existing logic (outside of my additions), is that when `func` is called now, it is passed the `assume_unique` kwarg for `np.setdiff1d` and `np.intersect1d` calls (`np.union1d` does not have that option). Previously that kwarg was not being passed in. Here is the code snippet that performs that:
```python3
func_kwargs = {} if is_union else dict(assume_unique=assume_unique) 
return func(array, other, **func_kwargs)
```

Other observations:

- Order is not being preserved as the docstrings suggest. The calls to `frozenset` are unordered, which means when that branch is hit, order promises are lost. I refrained from addressing that in this PR in order to keep the changes atomic.
- `nan`s do not seem to be handled correctly. See the following code snippet:
```python3
>>> a = np.array([1, 2, np.nan, np.nan])
>>> b = np.array([3, np.nan, 4, np.nan])
>>> sf.core.util.intersect1d(a, b)
array([], dtype=float64)
>>> sf.core.util.union1d(a, b)
array([ 1.,  2.,  3.,  4., nan, nan, nan, nan])
>>> sf.core.util.setdiff1d(a, b)
array([ 1.,  2., nan, nan])
```