### PR TITLE
Fixes edge hypothesis failure in test_setdiff1d

### DIFF
--- a/static_frame/test/property/test_util.py
+++ b/static_frame/test/property/test_util.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from hypothesis import strategies as st
 from hypothesis import given  # type: ignore
-from hypothesis import reproduce_failure
 
 from static_frame.core.util import DTYPE_NAN_KIND
 from static_frame.test.property.strategies import DTGroup

--- a/static_frame/test/property/test_util.py
+++ b/static_frame/test/property/test_util.py
@@ -319,6 +319,7 @@ class TestUnit(TestCase):
                 and not np.isnan(post).any()):
             self.assertSetEqual(set(post), (set(arrays[0]) & set(arrays[1])))
 
+
     @given(st.lists(get_array_1d(), min_size=2, max_size=2)) # type: ignore
     def test_setdiff1d(self, arrays: tp.Sequence[np.ndarray]) -> None:
         post = util.setdiff1d(


### PR DESCRIPTION
Per the failure in this test run, https://travis-ci.org/github/InvestmentSystems/static-frame/jobs/682130530, this PR addresses an issue with the test `test_setdiff1d`.

Basically, the old test was naively converting all arrays to python sets, resulting in loss of float precision. This change will now compare `post` against the result from a direct `np.setdiff1d` call when the inputs are numbers, as that is the expected behavior.