### PR TITLE
Fixes type_blocks reference cycle.

### DIFF
--- a/static_frame/core/type_blocks.py
+++ b/static_frame/core/type_blocks.py
@@ -273,7 +273,7 @@ class TypeBlocks(ContainerOperand):
         return a
 
     @property
-    def iloc(self) -> InterfaceGetItem:
+    def iloc(self) -> InterfaceGetItem: #type: ignore
         return InterfaceGetItem(self._extract_iloc)
 
     @property #type: ignore

--- a/static_frame/core/type_blocks.py
+++ b/static_frame/core/type_blocks.py
@@ -64,7 +64,6 @@ class TypeBlocks(ContainerOperand):
             '_index',
             '_shape',
             '_row_dtype',
-            'iloc',
             )
 
     STATIC = False
@@ -229,8 +228,6 @@ class TypeBlocks(ContainerOperand):
             # NOTE: this violates the type; however, this is desirable when appending such that this value does not force an undesirable type resolution
             self._row_dtype = None
 
-        self.iloc = InterfaceGetItem(self._extract_iloc)
-
     #---------------------------------------------------------------------------
     def __setstate__(self, state: tp.Tuple[object, tp.Mapping[str, tp.Any]]) -> None:
         '''
@@ -275,6 +272,9 @@ class TypeBlocks(ContainerOperand):
         a.flags.writeable = False
         return a
 
+    @property
+    def iloc(self) -> InterfaceGetItem:
+        return InterfaceGetItem(self._extract_iloc)
 
     @property #type: ignore
     @doc_inject()

--- a/static_frame/test/property/test_frame.py
+++ b/static_frame/test/property/test_frame.py
@@ -4,6 +4,7 @@ import unittest
 import operator
 import os
 import sqlite3
+import gc
 
 import numpy as np
 
@@ -354,6 +355,10 @@ class TestUnit(TestCase):
     def test_frame_to_latex(self, f1: Frame) -> None:
         post = f1.to_latex()
         self.assertTrue(len(post) > 0)
+
+    @given(sfst.get_frame_or_frame_go())
+    def test_frame_blocks_dont_have_reference_cycles(self, f1: Frame) -> None:
+        self.assertEqual([f1], gc.get_referrers(f1._blocks))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There is a sneaky reference cycle happening in the creation of type_blocks. Essentially, every type_blocks instance has an attribute `iloc` that contained a reference to an instance of `InterfaceGetItem`, which in turn has a reference to the type_blocks instance itself. This meant that when a frame was deleted, it's underlying type_block structure would hang around, since it was still referenced by the `InterfaceGetItem` instance, which itself was referenced by the type_blocks instance, which was reference by the `InterfaceGetItem` instance, and on and on and on. (Many thanks to @brandtbucher for helping to isolate this bug).

Here is an interesting example of how this reference cycle could lead to memory issues:
```python3
import gc
size = 10_000

f = sf.Frame(np.arange(size*size).reshape(size, size))

sel = np.full(size, True)

for _ in range(20): # Each additional iteration adds ~1GB of additional memory.
    f = f.loc[sel]

gc.collect() # This will free ~20GBs of memory, by isolating and deleting the 20 different type_blocks that only exist in a reference cycle.
```

An additional perk of this change is that it now conforms `type_blocks.iloc` to the pattern of `Frame` and `Series`. I also think it's reasonable to assume/hope this change will lead to performance/memory improvements across the board.