### PR TITLE
Fix for saving frames to sqlite, when labels contain special characters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist
 
 *.egg-info
 *.so
+
+# Wing
+*.wp[ur]

--- a/static_frame/core/store_sqlite.py
+++ b/static_frame/core/store_sqlite.py
@@ -89,13 +89,13 @@ class StoreSQLite(Store):
                 )
 
         create_fields = ', '.join(f'{k} {v}' for k, v in field_name_to_field_type)
-        create = f'CREATE TABLE {label} ({create_fields}{create_primary_key})'
+        create = f'CREATE TABLE "{label}" ({create_fields}{create_primary_key})'
         cursor.execute(create)
 
         # works for IndexHierarchy too
         insert_fields = ', '.join(f'{k}' for k in field_names)
         insert_template = ', '.join('?' for _ in field_names)
-        insert = f'INSERT INTO {label} ({insert_fields}) VALUES ({insert_template})'
+        insert = f'INSERT INTO "{label}" ({insert_fields}) VALUES ({insert_template})'
 
         values = cls._get_row_iterator(frame=frame, include_index=include_index)
         cursor.executemany(insert, values())
@@ -175,7 +175,7 @@ class StoreSQLite(Store):
                 detect_types=sqlite3.PARSE_DECLTYPES
                 ) as conn:
             # cursor = conn.cursor()
-            query = f'SELECT * from {label}'
+            query = f'SELECT * from "{label}"'
             return tp.cast(Frame, container_type.from_sql(query=query,
                     connection=conn,
                     index_depth=config.index_depth,

--- a/static_frame/test/unit/test_store_sqlite.py
+++ b/static_frame/test/unit/test_store_sqlite.py
@@ -67,7 +67,7 @@ class TestUnit(TestCase):
                         x=(Fraction(3,2), Fraction(1,2), Fraction(2,3), Fraction(3,7)),
                         y=(3,4,-5,-3000)),
                 index=IndexHierarchy.from_product(('I', 'II'), ('a', 'b')),
-                name='f1')
+                name='f1-dash')
 
         frames = (f1,)
 


### PR DESCRIPTION
The case that prompted this pull request was a dash in the `label` (which becomes table name). You can see the failure by checking out db4a26a and running the `store_sqlite` tests. 

The fix is just to quote the label in generated sql.