### PR TITLE
Test using Python 3.8.

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,6 +1,10 @@
 name: Quality
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 jobs:
   build:
@@ -14,6 +18,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
+    
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: quality-pip-${{ hashFiles('requirements-test.txt', '.github/workflows/quality.yml') }}
+#         restore-keys: quality-pip-
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         path: ~/.cache/pip
         key: quality-pip-${{ hashFiles('requirements-test.txt', '.github/workflows/quality.yml') }}
-#         restore-keys: quality-pip-
+        restore-keys: quality-pip-
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test
 
 on: [push, pull_request]
 
-env:
-  CFLAGS: -Wno-error=implicit-function-declaration
-
 jobs:
   build:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  CFLAGS: '-Wno-error=implicit-function-declaration'
+
 jobs:
   build:
 
@@ -27,7 +30,7 @@ jobs:
         pip install numpy==1.16.5
         pip install Cython==0.29.13
         pip install setuptools==41.2.0
-        pip install -r requirements-test.txt --no-binary pandas
+        pip install -r requirements-test.txt
 
     - name: Invoke Test
       run: inv test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test
 
 on: [push, pull_request]
 
-env:
-  CFLAGS: '-Wno-error=implicit-function-declaration'
-
 jobs:
   build:
 
@@ -30,7 +27,7 @@ jobs:
         pip install numpy==1.16.5
         pip install Cython==0.29.13
         pip install setuptools==41.2.0
-        pip install -r requirements-test.txt
+        CFLAGS='-Wno-error=implicit-function-declaration' pip install -r requirements-test.txt
 
     - name: Invoke Test
       run: inv test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-18.04', 'windows-2019', 'macos-10.15']
-        python-version: [3.6, 3.7] # 3.8 / pandas does not work on macos yet
+        python-version: [3.6, 3.7, 3.8]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       if: startsWith(matrix.os, 'macos-')
       with:
         path: ~/Library/Caches/pip
-        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml) }}
+        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
         restore-keys: test-pip-${{ matrix.os }}-
 
     - name: Restore cache (Windows)
@@ -44,7 +44,7 @@ jobs:
       if: startsWith(matrix.os, 'windows-')
       with:
         path: ~\AppData\Local\pip\Cache
-        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml) }}
+        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
         restore-keys: test-pip-${{ matrix.os }}-
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-18.04', 'windows-2019', 'macos-10.15']
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+# env:
+#   CFLAGS: -Wno-error=implicit-function-declaration
+
 jobs:
   build:
 
@@ -26,7 +29,7 @@ jobs:
       with:
         path: ~/.cache/pip
         key: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
-        restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
+#         restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Restore cache (MacOS)
       uses: actions/cache@v2
@@ -34,7 +37,7 @@ jobs:
       with:
         path: ~/Library/Caches/pip
         key: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
-        restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
+#         restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Restore cache (Windows)
       uses: actions/cache@v2
@@ -42,7 +45,7 @@ jobs:
       with:
         path: ~\AppData\Local\pip\Cache
         key: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
-        restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
+#         restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 env:
   CFLAGS: -Wno-error=implicit-function-declaration
@@ -29,7 +33,7 @@ jobs:
       with:
         path: ~/.cache/pip
         key: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
-#         restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
+        restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Restore cache (MacOS)
       uses: actions/cache@v2
@@ -37,7 +41,7 @@ jobs:
       with:
         path: ~/Library/Caches/pip
         key: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
-#         restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
+        restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Restore cache (Windows)
       uses: actions/cache@v2
@@ -45,7 +49,7 @@ jobs:
       with:
         path: ~\AppData\Local\pip\Cache
         key: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
-#         restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
+        restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,24 +28,24 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu-')
       with:
         path: ~/.cache/pip
-        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
-        restore-keys: test-pip-${{ matrix.os }}-
+        key: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
+        restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Restore cache (MacOS)
       uses: actions/cache@v2
       if: startsWith(matrix.os, 'macos-')
       with:
         path: ~/Library/Caches/pip
-        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
-        restore-keys: test-pip-${{ matrix.os }}-
+        key: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
+        restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Restore cache (Windows)
       uses: actions/cache@v2
       if: startsWith(matrix.os, 'windows-')
       with:
         path: ~\AppData\Local\pip\Cache
-        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
-        restore-keys: test-pip-${{ matrix.os }}-
+        key: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
+        restore-keys: test-pip-${{ matrix.os }}-${{ matrix.python-version }}-
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  CFLAGS: -Wno-error=implicit-function-declaration
+
 jobs:
   build:
 
@@ -27,7 +30,7 @@ jobs:
         pip install numpy==1.16.5
         pip install Cython==0.29.13
         pip install setuptools==41.2.0
-        CFLAGS='-Wno-error=implicit-function-declaration' pip install -r requirements-test.txt
+        pip install -r requirements-test.txt
 
     - name: Invoke Test
       run: inv test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         pip install numpy==1.16.5
         pip install Cython==0.29.13
         pip install setuptools==41.2.0
-        pip install -r requirements-test.txt
+        pip install -r requirements-test.txt --no-binary pandas
 
     - name: Invoke Test
       run: inv test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ name: Test
 
 on: [push, pull_request]
 
-# env:
-#   CFLAGS: -Wno-error=implicit-function-declaration
+env:
+  CFLAGS: -Wno-error=implicit-function-declaration
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-18.04', 'windows-2019', 'macos-10.15']
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
 
@@ -22,6 +22,30 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    
+    - name: Restore cache (Ubuntu)
+      uses: actions/cache@v2
+      if: startsWith(matrix.os, 'ubuntu-')
+      with:
+        path: ~/.cache/pip
+        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml') }}
+        restore-keys: test-pip-${{ matrix.os }}-
+
+    - name: Restore cache (MacOS)
+      uses: actions/cache@v2
+      if: startsWith(matrix.os, 'macos-')
+      with:
+        path: ~/Library/Caches/pip
+        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml) }}
+        restore-keys: test-pip-${{ matrix.os }}-
+
+    - name: Restore cache (Windows)
+      uses: actions/cache@v2
+      if: startsWith(matrix.os, 'windows-')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: test-pip-${{ matrix.os }}-${{ hashFiles('requirements-test.txt', '.github/workflows/test.yml) }}
+        restore-keys: test-pip-${{ matrix.os }}-
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This PR:

- Sets `CFLAGS` to ignore the compiler warnings that were failing Pandas builds for Python 3.8 using Clang (meaning we can test on Python 3.8 / macOS again).
- Adds caching for pip's built wheels, which can reduce the overhead of each run by up to 12 minutes.
- Removes duplicate jobs. Currently, all PR commits run each job *twice*, which takes forever.

In short, it makes CI better and faster. 🙂