### PR TITLE
Start shipping a `py.typed` file.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include requirements.txt requirements-extras.txt requirements-test.txt LICENSE.txt
+include requirements.txt requirements-extras.txt requirements-test.txt LICENSE.txt static_frame/py.typed

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     url='https://github.com/InvestmentSystems/static-frame',
     author='Christopher Ariza',
     license='MIT',
+    package_data={'static_frame': ['py.typed']},
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[


### PR DESCRIPTION
Currently, all symbols imported from `static_frame` in user code are seen by type-checkers as `typing.Any`.

The presence of this file in a distribution indicates to tools like mypy that the annotations in `static_frame` can actually be used when linting user code.

https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages