### PR TITLE
Adds a weak_cache to underlying store containers.

### DIFF
--- a/static_frame/core/bus.py
+++ b/static_frame/core/bus.py
@@ -1,4 +1,3 @@
-
 import typing as tp
 
 import numpy as np
@@ -227,7 +226,6 @@ class Bus(ContainerBase, StoreClientMixin): # not a ContainerOperand
                 max_persist=max_persist,
                 own_data=True,
                 )
-
 
     @classmethod
     @doc_inject(selector='bus_constructor')

--- a/static_frame/core/store.py
+++ b/static_frame/core/store.py
@@ -6,6 +6,7 @@ import os
 from itertools import chain
 from functools import partial
 from functools import wraps
+from weakref import WeakValueDictionary
 import numpy as np
 
 from static_frame.core.interface_meta import InterfaceMeta
@@ -440,7 +441,8 @@ class Store:
 
     __slots__ = (
             '_fp',
-            '_last_modified'
+            '_last_modified',
+            '_weak_cache',
             )
 
     def __init__(self, fp: PathSpecifier):
@@ -454,6 +456,7 @@ class Store:
         self._fp: str = fp
         self._last_modified = np.nan
         self._mtime_update()
+        self._weak_cache: tp.MutableMapping[tp.Hashable, Frame] = WeakValueDictionary()
 
     def _mtime_update(self) -> None:
         if os.path.exists(self._fp):

--- a/static_frame/core/store_zip.py
+++ b/static_frame/core/store_zip.py
@@ -1,5 +1,4 @@
 import typing as tp
-import weakref
 import zipfile
 import pickle
 from io import StringIO
@@ -112,7 +111,7 @@ class _StoreZip(Store):
 
         def get_from_weak_cache(label: tp.Hashable) -> Frame:
             frame = self._weak_cache[label]
-            if type(frame) is not container_type:
+            if frame.__class__ is not container_type:
                 return frame._to_frame(container_type)
             return frame
 

--- a/static_frame/core/store_zip.py
+++ b/static_frame/core/store_zip.py
@@ -4,7 +4,6 @@ import pickle
 from io import StringIO
 from io import BytesIO
 from concurrent.futures import ProcessPoolExecutor
-from concurrent.futures import Future
 # import multiprocessing as mp
 # mp_context = mp.get_context('spawn')
 

--- a/static_frame/core/store_zip.py
+++ b/static_frame/core/store_zip.py
@@ -5,7 +5,6 @@ from io import StringIO
 from io import BytesIO
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import Future
-from static_frame.core.doc_str import F
 # import multiprocessing as mp
 # mp_context = mp.get_context('spawn')
 

--- a/static_frame/core/store_zip.py
+++ b/static_frame/core/store_zip.py
@@ -191,7 +191,7 @@ class _StoreZip(Store):
             loop, as they both share the same necessary & initial condition: `if cached_frame is not None`.
             """
             with zipfile.ZipFile(self._fp) as zf:
-                for label, cached_frame in results.items():
+                for label, cached_frame in results_items():
                     if cached_frame is not None:
                         continue
 

--- a/static_frame/core/store_zip.py
+++ b/static_frame/core/store_zip.py
@@ -77,15 +77,6 @@ class _StoreZip(Store):
                 constructor=payload.constructor,
                 )
 
-    @classmethod
-    def _payloads_to_frames(cls,
-            payloads: tp.List[PayloadBytesToFrame],
-            ) -> tp.List[Frame]:
-        '''
-        Single argument wrapper for _build_frame().
-        '''
-        return [cls._payload_to_frame(payload) for payload in payloads]
-
     @staticmethod
     def _set_container_type(frame: Frame, container_type: tp.Type[Frame]) -> Frame:
         """

--- a/static_frame/core/store_zip.py
+++ b/static_frame/core/store_zip.py
@@ -179,8 +179,8 @@ class _StoreZip(Store):
             results_items = lambda: yield from zip(labels, repeat(None))
 
         # Avoid spinning up a process pool if all requested labels had weakrefs
-        if cache_hits == len(results):
-            for frame in results.values():
+        if count_cache and count_cache == count_labels:
+            for _, frame in results_items():
                 assert frame is not None  # mypy
                 yield frame
             return

--- a/static_frame/core/util.py
+++ b/static_frame/core/util.py
@@ -301,6 +301,9 @@ NAME_DEFAULT = object()
 STORE_LABEL_DEFAULT = object()
 
 #-------------------------------------------------------------------------------
+NOT_IN_CACHE_SENTINEL = object()
+
+#-------------------------------------------------------------------------------
 # operator mod does not have r methods; create complete method reference
 OPERATORS: tp.Dict[str, UFunc] = {
     '__pos__': operator.__pos__,

--- a/static_frame/test/unit/test_store_zip.py
+++ b/static_frame/test/unit/test_store_zip.py
@@ -71,7 +71,7 @@ class TestUnit(TestCase):
             self.assertEqual(labels, ('foo.txt', 'bar.txt', 'baz.txt'))
 
             for label, frame in ((f.name, f) for f in (f1, f2, f3)):
-                for read_max_workers in (1, 2):
+                for read_max_workers in (None, 1, 2):
                     config = StoreConfig(index_depth=1, read_max_workers=read_max_workers)
                     frame_stored = st.read(label, config=config)
                     self.assertEqual(frame_stored.shape, frame.shape)

--- a/static_frame/test/unit/test_store_zip.py
+++ b/static_frame/test/unit/test_store_zip.py
@@ -27,6 +27,28 @@ from static_frame.test.test_case import temp_file
 from static_frame.core.exception import ErrorInitStore
 # from static_frame.core.exception import ErrorInitStoreConfig
 
+def get_test_framesA(container_type: tp.Type[Frame] = Frame) -> tp.Tuple[Frame, Frame, Frame]:
+    return (
+            container_type.from_dict(
+                dict(a=(1,2), b=(3,4)),
+                index=('x', 'y'),
+                name='foo'),
+            container_type.from_dict(
+                dict(a=(1,2,3), b=(4,5,6)),
+                index=('x', 'y', 'z'),
+                name='bar'),
+            container_type.from_dict(
+                dict(a=(10,20), b=(50,60)),
+                index=('p', 'q'),
+                name='baz')
+            )
+
+def get_test_framesB() -> tp.Tuple[Frame, Frame]:
+    return (
+            ff.parse('s(4,4)|i(ID,dtD)|v(int)').rename('a'),
+            ff.parse('s(4,4)|i(ID,dtD)|v(int)').rename('b'),
+            )
+
 
 class TestUnit(TestCase):
     #---------------------------------------------------------------------------
@@ -49,18 +71,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_tsv_a(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-        f2 = Frame.from_dict(
-                dict(a=(1,2,3), b=(4,5,6)),
-                index=('x', 'y', 'z'),
-                name='bar')
-        f3 = Frame.from_dict(
-                dict(a=(10,20), b=(50,60)),
-                index=('p', 'q'),
-                name='baz')
+        f1, f2, f3 = get_test_framesA()
 
         with temp_file('.zip') as fp:
 
@@ -84,18 +95,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_csv_a(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-        f2 = Frame.from_dict(
-                dict(a=(1,2,3), b=(4,5,6)),
-                index=('x', 'y', 'z'),
-                name='bar')
-        f3 = Frame.from_dict(
-                dict(a=(10,20), b=(50,60)),
-                index=('p', 'q'),
-                name='baz')
+        f1, f2, f3 = get_test_framesA()
 
         with temp_file('.zip') as fp:
 
@@ -115,10 +115,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_csv_b(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
+        f1, *_ = get_test_framesA()
 
         with temp_file('.zip') as fp:
 
@@ -132,18 +129,7 @@ class TestUnit(TestCase):
     #---------------------------------------------------------------------------
     def test_store_zip_pickle_a(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-        f2 = Frame.from_dict(
-                dict(a=(1,2,3), b=(4,5,6)),
-                index=('x', 'y', 'z'),
-                name='bar')
-        f3 = Frame.from_dict(
-                dict(a=(10,20), b=(50,60)),
-                index=('p', 'q'),
-                name='baz')
+        f1, f2, f3 = get_test_framesA()
 
         with temp_file('.zip') as fp:
 
@@ -169,13 +155,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_pickle_b(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-
-        # config = StoreConfig(index_depth=1, include_index=True)
-        # config_map = StoreConfigMap.from_config(config)
+        f1, *_ = get_test_framesA()
 
         with temp_file('.zip') as fp:
 
@@ -187,10 +167,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_pickle_c(self) -> None:
 
-        f1 = FrameGO.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
+        f1, *_ = get_test_framesA(FrameGO)
 
         with temp_file('.zip') as fp:
             st = StoreZipPickle(fp)
@@ -202,10 +179,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_pickle_d(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
+        f1, *_ = get_test_framesA()
 
         with temp_file('.zip') as fp:
             for read_max_workers in (1, 2):
@@ -227,18 +201,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_pickle_e(self) -> None:
 
-        f1 = FrameGO.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-        f2 = FrameGO.from_dict(
-                dict(a=(1,2,3), b=(4,5,6)),
-                index=('x', 'y', 'z'),
-                name='bar')
-        f3 = FrameGO.from_dict(
-                dict(a=(10,20), b=(50,60)),
-                index=('p', 'q'),
-                name='baz')
+        f1, f2, f3 = get_test_framesA(FrameGO)
 
         with temp_file('.zip') as fp:
             st = StoreZipPickle(fp)
@@ -258,18 +221,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_parquet_a(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-        f2 = Frame.from_dict(
-                dict(a=(1,2,3), b=(4,5,6)),
-                index=('x', 'y', 'z'),
-                name='bar')
-        f3 = Frame.from_dict(
-                dict(a=(10,20), b=(50,60)),
-                index=('p', 'q'),
-                name='baz')
+        f1, f2, f3 = get_test_framesA()
 
         with temp_file('.zip') as fp:
             for read_max_workers in (1, 2):
@@ -289,19 +241,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_parquet_b(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-        f2 = Frame.from_dict(
-                dict(a=(1,2,3), b=(4,5,6)),
-                index=('x', 'y', 'z'),
-                name='bar')
-        f3 = Frame.from_dict(
-                dict(a=(10,20), b=(50,60)),
-                index=('p', 'q'),
-                name='baz')
-
+        f1, f2, f3 = get_test_framesA()
 
         with temp_file('.zip') as fp:
             for read_max_workers in (1, 2):
@@ -317,8 +257,7 @@ class TestUnit(TestCase):
 
     def test_store_zip_parquet_c(self) -> None:
 
-        f1 = ff.parse('s(4,4)|i(ID,dtD)|v(int)').rename('a')
-        f2 = ff.parse('s(4,4)|i(ID,dtD)|v(int)').rename('b')
+        f1, f2 = get_test_framesB()
 
         config = StoreConfig(
                 index_depth=1,
@@ -342,18 +281,7 @@ class TestUnit(TestCase):
 
     def test_store_read_many_single_thread_weak_cache(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-        f2 = Frame.from_dict(
-                dict(a=(1,2,3), b=(4,5,6)),
-                index=('x', 'y', 'z'),
-                name='bar')
-        f3 = Frame.from_dict(
-                dict(a=(10,20), b=(50,60)),
-                index=('p', 'q'),
-                name='baz')
+        f1, f2, f3 = get_test_framesA()
 
         with temp_file('.zip') as fp:
 
@@ -390,18 +318,7 @@ class TestUnit(TestCase):
 
     def test_store_read_many_multiprocess_weak_cache_a(self) -> None:
 
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-        f2 = Frame.from_dict(
-                dict(a=(1,2,3), b=(4,5,6)),
-                index=('x', 'y', 'z'),
-                name='bar')
-        f3 = Frame.from_dict(
-                dict(a=(10,20), b=(50,60)),
-                index=('p', 'q'),
-                name='baz')
+        f1, f2, f3 = get_test_framesA()
 
         with temp_file('.zip') as fp:
 
@@ -454,19 +371,7 @@ class TestUnit(TestCase):
 class TestUnitMultiProcess(TestCase):
 
     def run_assertions(self, klass: tp.Type[_StoreZip]) -> None:
-        f1 = Frame.from_dict(
-                dict(a=(1,2), b=(3,4)),
-                index=('x', 'y'),
-                name='foo')
-        f2 = Frame.from_dict(
-                dict(a=(1,2,3), b=(4,5,6)),
-                index=('x', 'y', 'z'),
-                name='bar')
-        f3 = Frame.from_dict(
-                dict(a=(10,20), b=(50,60)),
-                index=('p', 'q'),
-                name='baz')
-
+        f1, f2, f3 = get_test_framesA()
         with temp_file('.zip') as fp:
             for max_workers in range(1, 6):
                 for chunksize in (1, 2, 3):
@@ -505,8 +410,7 @@ class TestUnitMultiProcess(TestCase):
 
     def test_store_zip_npz_a(self) -> None:
 
-        f1 = ff.parse('s(4,4)|i(ID,dtD)|v(int)').rename('a')
-        f2 = ff.parse('s(4,4)|i(ID,dtD)|v(int)').rename('b')
+        f1, f2 = get_test_framesB()
 
         config = StoreConfig()
 

--- a/static_frame/test/unit/test_store_zip.py
+++ b/static_frame/test/unit/test_store_zip.py
@@ -11,7 +11,7 @@ from static_frame.core.frame import FrameHE
 from static_frame.core.index_datetime import IndexDate
 
 from static_frame.core.store import StoreConfig
-# from static_frame.core.store import StoreConfigMap
+from static_frame.core.store import StoreConfigMap
 
 from static_frame.core.store_zip import _StoreZip
 from static_frame.core.store_zip import StoreZipTSV
@@ -254,7 +254,6 @@ class TestUnit(TestCase):
             self.assertTrue(post[1].__class__ is Frame)
             self.assertTrue(post[2].__class__ is Frame)
 
-
     #---------------------------------------------------------------------------
 
     def test_store_zip_parquet_a(self) -> None:
@@ -341,6 +340,116 @@ class TestUnit(TestCase):
             self.assertIs(post[0].index.__class__, IndexDate)
             self.assertIs(post[1].index.__class__, IndexDate)
 
+    def test_store_read_many_single_thread_weak_cache(self) -> None:
+
+        f1 = Frame.from_dict(
+                dict(a=(1,2), b=(3,4)),
+                index=('x', 'y'),
+                name='foo')
+        f2 = Frame.from_dict(
+                dict(a=(1,2,3), b=(4,5,6)),
+                index=('x', 'y', 'z'),
+                name='bar')
+        f3 = Frame.from_dict(
+                dict(a=(10,20), b=(50,60)),
+                index=('p', 'q'),
+                name='baz')
+
+        with temp_file('.zip') as fp:
+
+            st = StoreZipTSV(fp)
+            st.write((f.name, f) for f in (f1, f2, f3))
+
+            kwargs = dict(
+                    config_map=StoreConfigMap.from_initializer(StoreConfig(index_depth=1)),
+                    constructor=st._container_type_to_constructor(Frame),
+                    container_type=Frame
+                    )
+
+            labels = tuple(st.labels(strip_ext=False))
+            self.assertEqual(labels, ('foo.txt', 'bar.txt', 'baz.txt'))
+
+            self.assertEqual(0, len(list(st._weak_cache)))
+
+            # Result is not held onto!
+            next(st._read_many_single_thread(('foo',), **kwargs))
+
+            self.assertEqual(0, len(list(st._weak_cache)))
+
+            # Result IS held onto!
+            frame = next(st._read_many_single_thread(('foo',), **kwargs))
+
+            self.assertEqual(1, len(list(st._weak_cache)))
+
+            # Reference in our weak_cache _is_ `frame`
+            self.assertIs(frame, st._weak_cache['foo'])
+            del frame
+
+            # Reference is gone now!
+            self.assertEqual(0, len(list(st._weak_cache)))
+
+    def test_store_read_many_multiprocess_weak_cache_a(self) -> None:
+
+        f1 = Frame.from_dict(
+                dict(a=(1,2), b=(3,4)),
+                index=('x', 'y'),
+                name='foo')
+        f2 = Frame.from_dict(
+                dict(a=(1,2,3), b=(4,5,6)),
+                index=('x', 'y', 'z'),
+                name='bar')
+        f3 = Frame.from_dict(
+                dict(a=(10,20), b=(50,60)),
+                index=('p', 'q'),
+                name='baz')
+
+        with temp_file('.zip') as fp:
+
+            st = StoreZipTSV(fp)
+            st.write((f.name, f) for f in (f1, f2, f3))
+
+            kwargs = dict(
+                    config=StoreConfig(index_depth=1, read_max_workers=1),
+                    container_type=Frame,
+                    )
+
+            labels = tuple(st.labels(strip_ext=True))
+            self.assertEqual(labels, ('foo', 'bar', 'baz'))
+
+            self.assertEqual(0, len(list(st._weak_cache)))
+
+            # Go through the pass where there are no cache hits!
+            # Don't hold onto the result!
+            list(st.read_many(labels, **kwargs))
+            self.assertEqual(0, len(list(st._weak_cache)))
+
+            # Hold onto all results
+            result = list(st.read_many(labels, **kwargs))
+            self.assertEqual(3, len(result))
+            self.assertEqual(3, len(list(st._weak_cache)))
+
+            del result
+            self.assertEqual(0, len(list(st._weak_cache)))
+
+            [frame] = list(st.read_many(("foo",), **kwargs))
+            self.assertIs(frame, st._weak_cache['foo'])
+
+            # Go through pass where there are some cache hits!
+            # Don't hold onto the result!
+            list(st.read_many(labels, **kwargs))
+            self.assertEqual(1, len(list(st._weak_cache)))
+
+            # Hold onto all results
+            result = list(st.read_many(labels, **kwargs))
+            self.assertEqual(3, len(result))
+            self.assertEqual(3, len(list(st._weak_cache)))
+
+            # Go through pass where all labels are in the cache
+            result2 = list(st.read_many(labels, **kwargs))
+            self.assertEqual(len(result), len(result2))
+            for f1, f2 in zip(result, result2):
+                self.assertIs(f1, f2)
+
 
 class TestUnitMultiProcess(TestCase):
 
@@ -389,6 +498,9 @@ class TestUnitMultiProcess(TestCase):
     def test_store_zip_parquet_mp(self) -> None:
         self.run_assertions(StoreZipParquet)
 
+    def test_store_zip_npz_mp(self) -> None:
+        self.run_assertions(StoreZipNPZ)
+
     #---------------------------------------------------------------------------
 
     def test_store_zip_npz_a(self) -> None:
@@ -409,6 +521,7 @@ class TestUnitMultiProcess(TestCase):
 
             self.assertIs(post[0].index.__class__, IndexDate)
             self.assertIs(post[1].index.__class__, IndexDate)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #306 

This turned out to be a relatively simple implementation, as the only use case of max_persist is when there exists an underlying store.

And it just so happens, that the logic for reading in from a store existing only in the base class, effectively meaning only a little bit of extra logic was needing to add this feature. I did end up cleaning up the internals just a little bit, but overall this is a lightweight change in terms of it's impact on the code base.