### PR TITLE
Prevent unhandled exception in ArchiveZip

### DIFF
--- a/static_frame/core/archive_npy.py
+++ b/static_frame/core/archive_npy.py
@@ -302,7 +302,10 @@ class ArchiveZip(Archive):
         self.memory_map = memory_map
 
     def __del__(self) -> None:
-        self._archive.close()
+        # Note: If the fp we were given didn't exist, _archive also doesn't exist.
+        archive = getattr(self, '_archive', None)
+        if archive:
+            archive.close()
 
     def write_array(self, name: str, array: np.ndarray) -> None:
         # NOTE: zip only has 'w' mode, not 'wb'

--- a/static_frame/test/unit/test_archive_npy.py
+++ b/static_frame/test/unit/test_archive_npy.py
@@ -553,7 +553,7 @@ class TestUnit(TestCase):
             with self.assertRaises(UnsupportedOperation):
                 _ = npy.nbytes
 
-    def test_archive_zip_missing_cleanup(self):
+    def test_archive_zip_missing_cleanup(self) -> None:
         # Test for cases where the specified file doesn't exist.
         buffer = StringIO()
         with contextlib.redirect_stderr(buffer):

--- a/static_frame/test/unit/test_archive_npy.py
+++ b/static_frame/test/unit/test_archive_npy.py
@@ -552,6 +552,20 @@ class TestUnit(TestCase):
             with self.assertRaises(UnsupportedOperation):
                 _ = npy.nbytes
 
+    def test_archive_zip_missing_cleanup(self):
+        # Test for cases where the specified file doesn't exist.
+        import contextlib
+        from io import StringIO
+        buffer = StringIO()
+        with contextlib.redirect_stderr(buffer):
+            with self.assertRaises(FileNotFoundError):
+                # Note at time of writing, the following is written to stderr
+                # `Exception ignored in: <function ArchiveZip.__del__>`
+                ArchiveZip('thisfiledoesntexist', writeable=False, memory_map=False)
+
+        # Assert that no error was printed to stderr.
+        self.assertEqual(buffer.getvalue(), '')
+
 
 if __name__ == '__main__':
     import unittest

--- a/static_frame/test/unit/test_archive_npy.py
+++ b/static_frame/test/unit/test_archive_npy.py
@@ -1,6 +1,7 @@
 import os
 from tempfile import TemporaryDirectory
-from io import UnsupportedOperation
+from io import UnsupportedOperation, StringIO
+import contextlib
 
 import numpy as np
 from numpy.lib.format import write_array # type: ignore
@@ -554,8 +555,6 @@ class TestUnit(TestCase):
 
     def test_archive_zip_missing_cleanup(self):
         # Test for cases where the specified file doesn't exist.
-        import contextlib
-        from io import StringIO
         buffer = StringIO()
         with contextlib.redirect_stderr(buffer):
             with self.assertRaises(FileNotFoundError):


### PR DESCRIPTION
If an ArchiveZip instance fails to instantiate because the filepath it was given doesn't exist, `__del__` raises an `AttributeError` because `_archive` doesn't exist.  The exception is recorded as [unraisable](https://docs.python.org/3/c-api/exceptions.html#c.PyErr_WriteUnraisable) (because it happens in `__del__`?) and is printed to stderr. This adds a test to demonstrate the issue, and fixes it. 