### PR TITLE
Mp context in `get_concurrent_executor`

### DIFF
--- a/static_frame/core/util.py
+++ b/static_frame/core/util.py
@@ -20,7 +20,6 @@ from io import StringIO
 from itertools import chain, zip_longest
 from os import PathLike
 
-
 import numpy as np
 import typing_extensions as tp
 from arraykit import (

--- a/static_frame/core/util.py
+++ b/static_frame/core/util.py
@@ -20,6 +20,7 @@ from io import StringIO
 from itertools import chain, zip_longest
 from os import PathLike
 
+
 import numpy as np
 import typing_extensions as tp
 from arraykit import (
@@ -1077,7 +1078,11 @@ def get_concurrent_executor(
     else:
         from concurrent.futures import ProcessPoolExecutor
 
-        exe = partial(ProcessPoolExecutor, max_workers=max_workers, mp_context=mp_context)  # pyright: ignore
+        exe = partial(
+            ProcessPoolExecutor,
+            max_workers=max_workers,
+            mp_context=mp.get_context(mp_context),
+        )  # pyright: ignore
     return exe  # type: ignore
 
 

--- a/static_frame/test/unit/test_util.py
+++ b/static_frame/test/unit/test_util.py
@@ -4,12 +4,11 @@ import datetime
 import json
 import unittest
 import warnings
+from concurrent.futures import ProcessPoolExecutor
 from enum import Enum
 from functools import partial
 from itertools import chain, repeat
 from types import MappingProxyType
-from concurrent.futures import ProcessPoolExecutor
-
 
 import frame_fixtures as ff
 import numpy as np
@@ -65,6 +64,7 @@ from static_frame.core.util import (
     dtype_to_fill_value,
     dtypes_retain_sortedness,
     gen_skip_middle,
+    get_concurrent_executor,
     get_tuple_constructor,
     intersect1d,
     intersect2d,
@@ -103,7 +103,6 @@ from static_frame.core.util import (
     union1d,
     union2d,
     validate_dtype_specifier,
-    get_concurrent_executor,
 )
 from static_frame.test.test_case import (
     TestCase,

--- a/static_frame/test/unit/test_util.py
+++ b/static_frame/test/unit/test_util.py
@@ -8,6 +8,8 @@ from enum import Enum
 from functools import partial
 from itertools import chain, repeat
 from types import MappingProxyType
+from concurrent.futures import ProcessPoolExecutor
+
 
 import frame_fixtures as ff
 import numpy as np
@@ -101,6 +103,7 @@ from static_frame.core.util import (
     union1d,
     union2d,
     validate_dtype_specifier,
+    get_concurrent_executor,
 )
 from static_frame.test.test_case import (
     TestCase,
@@ -3290,6 +3293,11 @@ class TestUnit(TestCase):
                 np.dtype(np.uint16),
             )
         )
+
+    def test_get_concurrent_executor_spawn_context(self) -> None:
+        e = get_concurrent_executor(use_threads=False, max_workers=1, mp_context='spawn')
+        with e() as executor:
+            self.assertIsInstance(executor, ProcessPoolExecutor)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In [util.py](https://github.com/static-frame/static-frame/blob/4d64f47d822bcd4cb162ba699e7c86aa6638404e/static_frame/core/util.py#L1062), the `mp_context` argument for `get_concurrent_executor` is typehinted as a string, but is passed to `ProcessPoolExecutor`, which expects a `multiprocessing.context.BaseContext` instance:


```python
TMpContext: tp.TypeAlias = tp.Literal['fork', 'forkserver', 'spawn'] | None


def get_concurrent_executor(
    *,
    use_threads: bool,
    max_workers: tp.Optional[int],
    mp_context: TMpContext,
) -> tp.Type[Executor]:
    # NOTE: these imports are conditional as these modules are not supported in pyodide
    exe: tp.Callable[..., Executor]
    if use_threads:
        from concurrent.futures import ThreadPoolExecutor

        exe = partial(ThreadPoolExecutor, max_workers=max_workers)
    else:
        from concurrent.futures import ProcessPoolExecutor

        exe = partial(ProcessPoolExecutor, max_workers=max_workers, mp_context=mp_context)  # pyright: ignore
    return exe  # type: ignore
```

This PR updates the function to call `multiprocessing.get_context(mp_context)`.